### PR TITLE
Publish W30 under MIT license

### DIFF
--- a/CATALOG.md
+++ b/CATALOG.md
@@ -2,7 +2,7 @@
 
 | 週次 | 主題 | 類型 | 難度 | 預估時間 | 狀態 |
 |---|---|---|---|---:|---|
-| [2026-W30](weeks/2026/2026-w30-gemini-screen-text-ocr/README.md) | Gemini 畫面文字 OCR | Chrome Extension | 中級 | 90 分鐘 | Preview |
+| [2026-W30](weeks/2026/2026-w30-gemini-screen-text-ocr/README.md) | Gemini 畫面文字 OCR | Chrome Extension | 中級 | 90 分鐘 | Stable |
 
 狀態定義：
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,13 @@
 
 ## Unreleased
 
+- 尚無。
+
+## 2026-W30 v1.0.0 — 2026-07-27
+
 - 建立 Winston 10xAI Toolspack 基礎結構。
 - 加入 AI Skill、Chrome Extension 與每週教學模板。
 - 加入本機與 GitHub Actions 驗證流程。
 - 加入 2026-W30「Gemini 畫面文字 OCR」Chrome Extension v0.6.2、教學講義、API 設定、架構、權限與疑難排解文件。
 - 加入框選與完整可視區快捷鍵、圖片 OCR、繁中翻譯、反白翻譯、單字庫與可重現測試。
+- 採用 MIT License，並將倉庫與 `2026-w30-v1.0.0` Release 公開發布。

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Winston
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 1. 前往 [CATALOG.md](CATALOG.md) 選擇一週內容。
 2. 打開該週的 `README.md`，先確認需要準備的工具。
-3. 不熟悉 Git 也沒關係：正式發布後可直接從 GitHub Releases 下載 ZIP。
+3. 不熟悉 Git 也沒關係：可直接從 [GitHub Releases](https://github.com/Winston774/Winston-10xAI-Toolspack/releases) 下載 ZIP。
 4. 完成任務後，依照該週的「成果證據」與「通過標準」自我檢查。
 5. 到 GitHub Discussions 分享成果；安裝或程式問題請建立 Issue。
 
@@ -38,7 +38,7 @@ scripts/     驗證與打包工具
 
 ## 最新內容
 
-- [2026-W30：Gemini 畫面文字 OCR](weeks/2026/2026-w30-gemini-screen-text-ocr/README.md) — 用快捷鍵框選圖片、影片或 Canvas 的文字，交給 Gemini 轉錄並翻譯。
+- [2026-W30：Gemini 畫面文字 OCR](weeks/2026/2026-w30-gemini-screen-text-ocr/README.md)（`1.0.0 Stable`）— 用快捷鍵框選圖片、影片或 Canvas 的文字，交給 Gemini 轉錄並翻譯。
 - 其他內容請查看 [完整目錄](CATALOG.md)。
 
 ## 給維護者
@@ -47,4 +47,4 @@ scripts/     驗證與打包工具
 
 ## 授權
 
-授權條款尚未定案。正式公開前，請分別決定範例程式碼與教材／圖片的使用範圍；在授權文件加入前，所有內容均保留權利。
+本倉庫的程式碼、教材與隨附素材依 [MIT License](LICENSE) 授權。

--- a/scripts/build-release.ps1
+++ b/scripts/build-release.ps1
@@ -6,6 +6,7 @@ param(
 $ErrorActionPreference = 'Stop'
 $resolvedWeek = (Resolve-Path -LiteralPath $WeekPath).Path
 $repoRoot = Split-Path -Parent $PSScriptRoot
+$licensePath = Join-Path $repoRoot 'LICENSE'
 $weeksRoot = [System.IO.Path]::GetFullPath((Join-Path $repoRoot 'weeks') + [System.IO.Path]::DirectorySeparatorChar)
 $resolvedWeekPath = [System.IO.Path]::GetFullPath($resolvedWeek)
 $pathComparison = if ([System.Environment]::OSVersion.Platform -eq [System.PlatformID]::Win32NT) {
@@ -26,6 +27,9 @@ foreach ($requiredFile in @('README.md', 'lesson.md', 'metadata.yml')) {
 }
 if (-not (Test-Path -LiteralPath (Join-Path $resolvedWeekPath 'completed') -PathType Container)) {
     throw 'WeekPath is missing completed'
+}
+if (-not (Test-Path -LiteralPath $licensePath -PathType Leaf)) {
+    throw 'Repository is missing LICENSE'
 }
 
 $metadataContent = Get-Content -LiteralPath (Join-Path $resolvedWeekPath 'metadata.yml') -Raw -Encoding UTF8
@@ -57,6 +61,18 @@ try {
     )
 
     try {
+        $licenseEntry = $archive.CreateEntry('LICENSE', [System.IO.Compression.CompressionLevel]::Optimal)
+        $licenseEntry.LastWriteTime = (Get-Item -LiteralPath $licensePath).LastWriteTime
+        $licenseInputStream = [System.IO.File]::OpenRead($licensePath)
+        $licenseOutputStream = $licenseEntry.Open()
+        try {
+            $licenseInputStream.CopyTo($licenseOutputStream)
+        }
+        finally {
+            $licenseOutputStream.Dispose()
+            $licenseInputStream.Dispose()
+        }
+
         $files = Get-ChildItem -LiteralPath $resolvedWeekPath -Recurse -File -Force | Sort-Object FullName
         foreach ($file in $files) {
             $entryName = $file.FullName.Substring($resolvedWeekPath.Length + 1).Replace('\', '/')
@@ -83,6 +99,7 @@ try {
     try {
         $entries = @($verificationArchive.Entries | ForEach-Object { $_.FullName })
         $requiredEntries = @(
+            'LICENSE',
             'README.md',
             'lesson.md',
             'metadata.yml'

--- a/weeks/2026/2026-w30-gemini-screen-text-ocr/README.md
+++ b/weeks/2026/2026-w30-gemini-screen-text-ocr/README.md
@@ -33,7 +33,7 @@
 - 預估時間：安裝與體驗約 30 分鐘；完整拆解約 90 分鐘
 - 支援平台：Windows／macOS／ChromeOS，Chrome 116 以上
 - Extension 版本：`0.6.2`
-- 本週內容版本：`0.9.0 Preview`；合併並建立正式 Release 後升為 `1.0.0 Stable`
+- 本週內容版本：`1.0.0 Stable`
 
 ## 需要準備
 
@@ -48,7 +48,7 @@ Gemini API 是否免費、可用額度與支援地區會隨模型、帳號和 Go
 
 不需要 Git，也不需要終端機：
 
-1. 正式發佈後，從 GitHub Releases 下載 `2026-w30-v1.0.0` 的 ZIP 並解壓縮。Preview 期間可在 GitHub 按 `Code → Download ZIP` 下載目前分支，再找到 `weeks/2026/2026-w30-gemini-screen-text-ocr/completed/gemini-selection-translator/`。
+1. 從 [`2026-w30-v1.0.0` GitHub Release](https://github.com/Winston774/Winston-10xAI-Toolspack/releases/tag/2026-w30-v1.0.0) 下載 `2026-w30-gemini-screen-text-ocr.zip` 並解壓縮。
 2. 在 Chrome 開啟 `chrome://extensions`。
 3. 打開右上角「開發人員模式」。
 4. 按「載入未封裝項目」。
@@ -133,5 +133,6 @@ Gemini API 是否免費、可用額度與支援地區會隨模型、帳號和 Go
 
 ## 版本紀錄
 
-- 本週內容 `v0.9.0 Preview`：首次整理進 Toolspack，包含 Extension `v0.6.2`、完整教學與驗證文件；完成 PR、CI 與正式 Release 後升為 `v1.0.0 Stable`。
+- 本週內容 `v1.0.0 Stable`：首次正式公開發布，包含 Extension `v0.6.2`、完整教學、驗證文件與 MIT License。
+- 本週內容 `v0.9.0 Preview`：首次整理進 Toolspack，並完成 PR、CI 與發布前驗證。
 - Extension `v0.6.2`：修正第一次只用自訂快捷鍵時缺少截圖權限的冷啟動問題，並完成 region／viewport 回歸測試。

--- a/weeks/2026/2026-w30-gemini-screen-text-ocr/metadata.yml
+++ b/weeks/2026/2026-w30-gemini-screen-text-ocr/metadata.yml
@@ -3,8 +3,8 @@ title: Gemini 畫面文字 OCR
 type: chrome-extension
 difficulty: intermediate
 estimated_minutes: 90
-status: preview
-published_at: null
-version: 0.9.0
+status: stable
+published_at: 2026-07-27
+version: 1.0.0
 artifact_version: 0.6.2
 minimum_chrome_version: 116

--- a/weeks/2026/README.md
+++ b/weeks/2026/README.md
@@ -8,4 +8,4 @@
 
 | 週次 | 主題 | 類型 | 狀態 |
 |---|---|---|---|
-| [2026-W30](2026-w30-gemini-screen-text-ocr/README.md) | Gemini 畫面文字 OCR | Chrome Extension | Preview |
+| [2026-W30](2026-w30-gemini-screen-text-ocr/README.md) | Gemini 畫面文字 OCR | Chrome Extension | Stable |


### PR DESCRIPTION
## What changed

- add the MIT License with copyright held by Winston
- promote the 2026-W30 unit from Preview to 1.0.0 Stable
- add the public Release links and release changelog entry
- include the repository LICENSE in every weekly Release ZIP

## Why

The teaching repository and its downloadable Chrome Extension package are being published for learners. The repository and the packaged artifact need an explicit license and stable release metadata before changing visibility to Public.

## Validation

- repository validator passed
- Extension tests: 66/66 passed
- JavaScript syntax checks: 9/9 passed
- Release ZIP: 39 entries, exactly one LICENSE, zero forbidden entries
- local ZIP SHA-256: `E6F382FD3DDDE2B71D52344D25383CF6949BD4C0D2511C94D468AAFB595E383C`