### PR TITLE
2026-W35: Mastery Loop

### DIFF
--- a/CATALOG.md
+++ b/CATALOG.md
@@ -2,6 +2,7 @@
 
 | 週次 | 主題 | 類型 | 難度 | 預估時間 | 狀態 |
 |---|---|---|---|---:|---|
+| [2026-W35](weeks/2026/2026-w35-mastery-loop/README.md) | Mastery Loop：可驗證的點擊式精熟學習系統 | AI Skill | 進階 | 240 分鐘 | Stable |
 | [2026-W34](weeks/2026/2026-w34-kinetic-character-reveal/README.md) | Kinetic Character Reveal：13-Cut 動態角色登場提示詞系統 | AI Skill | 中級 | 90 分鐘 | Stable |
 | [2026-W33](weeks/2026/2026-w33-index-studio-indextts-2-5/README.md) | Index Studio：IndexTTS 2.5 本機語音實驗工作台 | Local AI Tool | 中級 | 120 分鐘 | Stable |
 | [2026-W32](weeks/2026/2026-w32-goal-me-agent-task-brief/README.md) | Goal Me：AI Agent 目標任務書 | AI Skill | 中級 | 60 分鐘 | Stable |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@
 
 - 尚無。
 
+## 2026-W35 v1.0.0 — 2026-08-28
+
+- 正式發布 Mastery Loop：可驗證的點擊式精熟學習系統。
+- 加入 version 3 批次 Assessment、證據連結 Learning Map、新情境 Review 與 delayed review。
+- 加入點擊優先介面、答案防洩漏、不可變 response、idempotent retry、phase lock 與 crash recovery。
+- 加入 90 項自動測試、完整安裝教學、資料隱私、安全邊界、驗證方式與疑難排解。
+
 ## 2026-W34 v1.0.0 — 2026-08-20
 
 - 正式發布 Kinetic Character Reveal：13-Cut 動態角色登場提示詞系統。

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ scripts/     驗證與打包工具
 
 ## 最新內容
 
+- [2026-W35：Mastery Loop — 可驗證的點擊式精熟學習系統](weeks/2026/2026-w35-mastery-loop/README.md)（`1.0.0 Stable`）— 以批次評估、證據連結學習地圖與新情境複習建立可續跑的學習循環。
 - [2026-W34：Kinetic Character Reveal — 13-Cut 動態角色登場提示詞系統](weeks/2026/2026-w34-kinetic-character-reveal/README.md)（`1.0.0 Stable`）— 抽取 Style DNA、鎖定角色與視覺規則，產生並驗證 15 秒動態角色登場 Prompt。
 - [2026-W33：Index Studio — IndexTTS 2.5 本機語音實驗工作台](weeks/2026/2026-w33-index-studio-indextts-2-5/README.md)（`1.0.0 Stable`）— 在 Windows 本機控制五語言、情緒、語速與發音，保存 WAV／JSON 做可重現 A/B。
 - [2026-W32：Goal Me — AI Agent 目標任務書](weeks/2026/2026-w32-goal-me-agent-task-brief/README.md)（`1.0.0 Stable`）— 將一句模糊想法轉成可獨立執行、續跑與驗收的 Agent 工作規格。

--- a/weeks/2026/2026-w35-mastery-loop/README.md
+++ b/weeks/2026/2026-w35-mastery-loop/README.md
@@ -1,0 +1,119 @@
+# 2026-W35：Mastery Loop — 可驗證的點擊式精熟學習系統
+
+> 把「我想學會」轉成一個有範圍、有證據、可續跑的評估 → 學習 → 新情境複習循環。
+
+## 本週成果
+
+本週提供 `mastery-loop v1.0.0`。安裝後，Agent 會先給三個可點擊目標，再依確認的任務建立完整批次評估、證據連結學習地圖與新情境複習。每次作答會立即保存，重新整理或重開後可從既有紀錄續跑。
+
+主要能力：
+
+- 以 10–20 題、3–6 個領域建立第一輪能力證據。
+- 每個選項都補充邊界、前提或取捨，作答前不洩漏答案。
+- 依實際答題缺口，為每個領域建立 5–10 個循序 Learning Slices。
+- 每個領域包含一個 formative checkpoint，錯誤會保存並進入後續複習。
+- 以 8–15 題全新情境做整合 Review，保留 Assessment → Learning → Review 的證據鏈。
+- 將殘留缺口排入三天後的無提示複習。
+- 使用本機 loopback 頁面、不可變回應與可恢復 checkpoint 保存學習狀態。
+
+成品位置：[`completed/mastery-loop/`](completed/mastery-loop/)
+
+延伸文件：
+
+- [完整教學講義](lesson.md)
+- [驗證方式與邊界](docs/verification.md)
+- [資料、隱私與安全](docs/privacy-and-security.md)
+- [疑難排解](docs/troubleshooting.md)
+
+## 基本資料
+
+- 類型：AI Skill
+- 難度：進階
+- 預估時間：安裝與設定約 15 分鐘；最小完整循環約 3–5 小時，可分段完成
+- 支援平台：Windows、macOS、Linux；Codex 或可讀取 Agent Skills 的 AI Agent
+- 需求：Python 3.10 以上；核心腳本只使用 Python 標準函式庫
+- Skill 版本：`1.0.0`
+- 本週狀態：`Stable`
+- API Key／付費服務：技能本身不需要；若學習主題要求即時研究，查證工具可能另有帳號或費用
+
+## 安裝與開始
+
+1. 從本週 GitHub Release 下載 `2026-w35-mastery-loop.zip` 並解壓縮。
+2. 找到 `completed/mastery-loop`。
+3. 將整個資料夾複製到：
+   - Windows：`%USERPROFILE%\.codex\skills\mastery-loop`
+   - macOS／Linux：`~/.codex/skills/mastery-loop`
+   - 共用 Agent Skills 目錄：`~/.agents/skills/mastery-loop`
+4. 重新啟動 Agent 工具，確認 `Mastery Loop` 出現在可用技能清單。
+5. 用一句話明確呼叫技能：
+
+```text
+使用 $mastery-loop，幫我建立一個「能規劃、委派、驗收多 Agent Workflow」的完整學習循環。
+```
+
+Agent 會先呈現三個可點擊目標：端到端交付、診斷改進、複習教學。選定後再確認範圍、評估依據與排除項目。
+
+新循環一律使用 version 3。`click_choice_ui.py` 只用於前置點擊確認，或續跑歷史 version 1／2 紀錄。
+
+## 核心 Workflow
+
+```text
+三個目標選項
+  → 確認可觀察成果與知識邊界
+  → 10–20 題 Assessment
+  → Assessment Report
+  → 3–6 領域 Learning Map
+  → 每領域 5–10 Slices + 1 Checkpoint
+  → 8–15 題 New-Scenario Review
+  → Comparison Report
+  → 三天後 Delayed Review
+```
+
+每個階段在同一個本機瀏覽器分頁完成。Agent 產生規格、驗證規格，再啟動頁面；學員只需點擊選項、提交與前往下一題。
+
+## 本週任務
+
+1. 選一個可以用具體行為驗收的目標，例如「能為一個三任務專案設計 Agent 分工、handoff 與失敗復原」。
+2. 從三個目標中點選一個，確認包含範圍、排除項目與證據限制。
+3. 完成整批 Assessment，不中途重設分數或刪除錯題。
+4. 檢查 Assessment Report：每個缺口都要指回原始題目與知識 kernel。
+5. 完成完整 Learning Map 與每個領域 checkpoint。
+6. 完成 Review，確認題目使用新情境，沒有複製 Assessment 或教學範例。
+7. 保存比較報告與三天後複習排程。
+
+## 成果證據
+
+- 一份已確認的任務範圍：3–6 個領域、包含／排除項目、評估依據與證據限制。
+- 完整 `assessment/report.json`，可追溯每個 gap 與 misconception。
+- 完整 `learning/report.json`，所有 slices 與 checkpoints 皆有不可變紀錄。
+- Review comparison report，分開標示已修正、殘留、整合覆蓋與新發現缺口。
+- 三天後 delayed review 的固定 due date 與 kernel 清單。
+- 若目標是端到端交付，再提供一份模擬或實作產物；單次點擊正確無法證明完整交付能力。
+
+## 通過標準
+
+- [ ] Skill 可被 Agent 辨識，或 Agent 能完整讀取 `SKILL.md` 與七份 references。
+- [ ] 新循環使用 version 3，學員決策優先採用點擊操作。
+- [ ] Assessment 有 10–20 題、3–6 個領域、每領域至少 2 題，且每題使用不同 kernel。
+- [ ] 作答前的畫面沒有正解、解析、內部 ID、未來題目或提示性選項描述。
+- [ ] 每次作答自動且不可變地保存，重新整理可回到正確狀態。
+- [ ] 每個領域有 5–10 個 Learning Slices 與恰好 1 個 checkpoint。
+- [ ] 每個 proposed gap 都連到至少一個 slice，每個 slice 也能回溯 Assessment 證據。
+- [ ] Review 有 8–15 題、涵蓋所有領域，並使用真正的新情境。
+- [ ] 最終報告沒有把閱讀、信心或同場提示後答對直接宣稱為 Transfer／Durable。
+- [ ] 殘留與新發現缺口已排入三天後的無提示複習。
+- [ ] 個人 `mastery-sessions/` 沒有進入 Git、分享 ZIP 或公開 Issue。
+
+## 失敗時的最短路徑
+
+1. Skill 沒觸發：以 `$mastery-loop` 明確呼叫，並確認資料夾沒有多包一層。
+2. 無法建立題目：先縮小目標，確保至少有 10 個可由可靠基準判定的知識 kernels。
+3. 頁面無法啟動：確認 Python 版本、cycle 路徑與 phase 規格，先執行 `validate`。
+4. 顯示 phase lock：關閉舊頁面與舊程序，保留 cycle 資料後再啟動。
+5. 提交後斷線：不要重建 cycle；以相同狀態重開，系統會依不可變紀錄復原。
+6. Review 無法生成：確認所有 slices 都完成，且每個 area checkpoint 都已有回應。
+7. 仍失敗：依[疑難排解](docs/troubleshooting.md)保留錯誤訊息、phase、cycle ID 與最小可重現步驟；分享前移除個人學習內容。
+
+## 版本紀錄
+
+- `v1.0.0 Stable`：version 3 批次 Assessment、證據連結 Learning Map、新情境 Review、不可變狀態、loopback 點擊介面與 90 項自動測試。

--- a/weeks/2026/2026-w35-mastery-loop/completed/mastery-loop/.gitignore
+++ b/weeks/2026/2026-w35-mastery-loop/completed/mastery-loop/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.py[cod]

--- a/weeks/2026/2026-w35-mastery-loop/completed/mastery-loop/SKILL.md
+++ b/weeks/2026/2026-w35-mastery-loop/completed/mastery-loop/SKILL.md
@@ -1,0 +1,140 @@
+---
+name: mastery-loop
+description: Run a stateful, click-first mastery system with a scoped 10-20 question batch assessment, an evidence-linked knowledge map, and an 8-15 question new-scenario review. Use for self-study, tutoring, capability audits, misconception diagnosis, or durable learning; use the legacy path only to resume historical v1/v2 single-question sessions.
+---
+
+# Mastery Loop
+
+## Outcome
+
+Run one evidence-aware learning cycle:
+
+```text
+three goal choices -> scope and benchmark -> 10-20 question Assessment
+                   -> assessment report -> 3-6 area Learning Map
+                   -> 5-10 slices per area + area checkpoint
+                   -> 8-15 question new-scenario Review
+                   -> comparison report + delayed review
+```
+
+Judge demonstrated performance. Confidence, credentials, fluency, reading completion, and exposure are context, not mastery evidence.
+
+## Default and Legacy Paths
+
+- Use **version 3** for every new cycle. Each phase runs continuously in one loopback browser tab through `scripts/mastery_session_ui.py`.
+- Use `scripts/click_choice_ui.py` for a pre-cycle goal/confirmation gate only when native clickable controls are unavailable, and to resume historical version 1 or 2 single-question sessions. Do not migrate or rewrite legacy specs, answers, or Review records.
+- A manual `記錄這個錯誤` action belongs only to the legacy path. Version 3 saves every committed answer atomically and never shows a record button or recording notice.
+
+## Mouse-First Contract
+
+Every learner-facing decision prefers a clickable control. Do not ask the learner to type option codes when a click path is available. Scored controls must not recommend, preselect, reorder unpredictably, or leak correctness.
+
+Read [references/choice-interface.md](references/choice-interface.md) before serving the first goal, Assessment, Learning, or Review page.
+
+## Start or Resume a Cycle
+
+1. Inspect `mastery-sessions/` for an active version 3 cycle and resume it from immutable records plus `checkpoint.json`.
+2. If no active cycle exists, present exactly three topic-specific outcomes:
+   - end-to-end delivery;
+   - diagnosis and improvement;
+   - review and teaching.
+3. Derive one observable ultimate outcome. Confirm, adjust scope, or pause through clickable actions.
+4. Define the knowledge boundary before testing: 3-6 major areas, included and excluded topics, benchmark status and sources, required performance, and evidence limits.
+5. Create files only when persistent learning work is in scope. Do not create a workspace for chat-only guidance.
+
+Read [references/workspace-schema.md](references/workspace-schema.md) before creating or changing cycle state.
+
+## Version 3 Workflow
+
+### 1. Assessment / 評估
+
+Generate the complete batch before the phase starts:
+
+- 10-20 questions across 3-6 major areas;
+- at least two questions per area;
+- one distinct `knowledge_kernel_id` per question;
+- 3-5 balanced clickable options and exactly one benchmark-supported answer; every pre-commit subdescription adds a neutral boundary, prerequisite, tradeoff, or omitted factor without evaluating correctness;
+- an explanation for every option and a misconception tag for each plausible wrong answer.
+
+The introduction shows the outcome, scope, exclusions, benchmark status and sources, area distribution, question count, and estimated time. During the batch, show question and area progress. After each commitment, lock the answer, save it automatically, show the selected and correct answers with their explanations, and offer one primary `下一題` action. Do not show cumulative scoring until the batch report.
+
+The report is rebuilt from server-side specs and immutable responses. Aggregate by area, show `穩定訊號`, `混合訊號`, or `待補強`, and trace every gap and misconception to source questions and proposed Learning Slices.
+
+Read [references/adaptive-interview.md](references/adaptive-interview.md) before building the scope, batch, or Assessment report.
+
+### 2. Learning / 學習
+
+Generate the Learning Map from the completed Assessment report:
+
+- preserve the same 3-6 areas;
+- create `min(5 + independent gap count, 10)` slices per area;
+- order slices by prerequisites and increasing complexity;
+- link each slice to relevant correct and wrong Assessment responses;
+- finish every area with one required formative checkpoint.
+
+Each slice states its map position, prerequisite, difficulty, observable outcome, core mechanism and boundary, worked example, common mistakes, summary, and sources. Completed slices remain available for review; locked downstream slices expose only their title and position. A wrong area checkpoint is saved and explained but does not block the next area.
+
+Reading completion updates progress only. Generate Review only after all slices and all area checkpoints are complete.
+
+Read [references/lesson-design.md](references/lesson-design.md) before producing the Learning Map, slices, checkpoints, or Learning report.
+
+### 3. Review / 複習
+
+Generate one integrated batch after Learning completes:
+
+```text
+question count = clamp(unique Assessment/Learning gap kernels + area count, 8, 15)
+```
+
+Prioritize Assessment mistakes, then checkpoint mistakes, mission-critical correct concepts, and cross-area integration. Each question has one `primary_kernel_id` for scoring and may name `integrated_kernel_ids`.
+
+Preserve the primary core proposition while changing the scenario, question family, prompt, option IDs and wording, distractors, and correct-answer position. Within the 15-question cap, assign direct primary scoring first to an Assessment gap in every gap-bearing area, then to remaining Assessment gaps by criticality, and then to checkpoint gaps. Every overflow gap must still appear as an integrated kernel with lineage, remain unresolved by direct scoring, and enter delayed review. The batch must cover every area, at least one cross-area integration, and every mission-critical correct kernel. Reject exact or trivial near-duplicate Assessment and Learning scenarios. Use the same continuous progress, immediate explanation, and automatic persistence behavior as Assessment.
+
+The final report compares Assessment and Review, separates corrected, residual, and newly exposed gaps, lists reinforced concepts, and schedules every residual or newly exposed gap for an uncued check three days later. End the current cycle after the report; do not start an unbounded immediate loop.
+
+Read [references/review-loop.md](references/review-loop.md) before generating the Review batch or comparison report.
+
+## Evidence and State
+
+- Preserve first-attempt evidence before feedback.
+- Label later same-kernel work `feedback_exposed`, `hinted`, `corrected`, or `independent` accurately.
+- A correct choice supports at most Fragile by itself; reading a slice supports no promotion.
+- End-to-end capability requires simulation or artifact evidence.
+- Transfer requires an uncued unseen structural variant; Durable requires meaningful delay.
+- Keep mission-critical blockers visible instead of hiding them in an average.
+
+Read [references/mastery-model.md](references/mastery-model.md) before changing evidence levels, confidence, or mastery claims.
+
+## Public CLI
+
+Validate a version 3 phase before serving it:
+
+```powershell
+python scripts/mastery_session_ui.py validate `
+  --workspace <workspace> `
+  --cycle mastery-sessions/<cycle-id> `
+  --phase assessment|learning|review
+
+python scripts/mastery_session_ui.py serve `
+  --workspace <workspace> `
+  --cycle mastery-sessions/<cycle-id> `
+  --phase assessment|learning|review `
+  --port 0
+```
+
+The server owns sequencing, scoring, reports, and resume state. `validate` is read-only. Assessment start seals the confirmed mission, scope, areas, and complete question batch. A writable server preflights contained write targets, acquires the cycle lock before any persisted report or checkpoint change, and joins active requests before releasing it. Never derive state from browser-supplied counts or correctness.
+
+## Boundaries and Stop Conditions
+
+- Defer scoring when no defensible benchmark-supported answer exists.
+- Verify current, niche, public-facing, legal, medical, financial, or safety-sensitive claims with current authoritative sources.
+- Pause when scope is incomplete, fewer than ten defensible kernels exist, a required artifact is missing, fatigue distorts evidence, the learner asks to stop, or the time box ends.
+- Preserve mouse-first operation, accessibility, respectful language, and the learner's authorization boundaries.
+- Do not infer intelligence, employability, personality, or general competence.
+- Formal certification requires validated instruments, identity controls, qualified assessors, and domain governance.
+
+## Completion Criteria
+
+A version 3 cycle is complete when the scope and benchmark are visible, Assessment contains 10-20 valid unique-kernel questions, every commitment is saved with immediate explanation, the Assessment report drives a complete Learning Map, all slices and area checkpoints finish, Review contains 8-15 valid new-scenario questions, the comparison report and delayed checks are persisted, and all mastery claims stay inside the tested mission.
+
+Before materially revising, validating, or packaging the skill, read [references/quality-rubric.md](references/quality-rubric.md).

--- a/weeks/2026/2026-w35-mastery-loop/completed/mastery-loop/agents/openai.yaml
+++ b/weeks/2026/2026-w35-mastery-loop/completed/mastery-loop/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Mastery Loop"
+  short_description: "Batch assessment, knowledge-map learning, and review"
+  default_prompt: "Use $mastery-loop to scope my goal, run a batch assessment, build an evidence-linked Learning Map, and finish with a new-scenario Review."

--- a/weeks/2026/2026-w35-mastery-loop/completed/mastery-loop/references/adaptive-interview.md
+++ b/weeks/2026/2026-w35-mastery-loop/completed/mastery-loop/references/adaptive-interview.md
@@ -1,0 +1,98 @@
+# Batch Assessment Protocol
+
+Use this protocol to define the scope, generate one complete Assessment batch, and produce its report. Adaptation happens before the batch and again at phase boundaries; never mutate an active batch from interim answers.
+
+## 1. Lock Outcome and Scope
+
+Start with exactly three clickable, topic-specific outcomes: end-to-end delivery, diagnosis and improvement, or review and teaching. Persist the selected stable intent ID and derive an observable ultimate outcome.
+
+Before any scored item, show and confirm:
+
+- the ultimate outcome and learner audience;
+- 3-6 major knowledge areas;
+- included and excluded topics;
+- expected performance and failure cost;
+- benchmark status and sources;
+- question distribution, total count, and estimated time;
+- known evidence limits and accommodations.
+
+Use supplied artifacts and authoritative materials before requesting extra intake. Mark the benchmark `verified`, `partially_verified`, or `provisional`. Defer scoring where no defensible answer exists.
+
+## 2. Build the Benchmark Map
+
+Create one row for each candidate kernel:
+
+```markdown
+| Area | Kernel ID | Core proposition | Why critical | Required level | Prerequisite | Failure signal | Source |
+|---|---|---|---|---|---|---|---|
+```
+
+Choose 3-6 coherent areas. If the confirmed scope cannot support at least ten distinct, benchmark-backed propositions, block Assessment and return to scope expansion.
+
+## 3. Compose the Batch
+
+Generate all 10-20 questions before serving the phase.
+
+- Give every area at least two questions.
+- Use one distinct `knowledge_kernel_id` per question, so immediate feedback cannot contaminate another baseline item in the same batch.
+- Allocate remaining questions by mission criticality, uncertainty, failure cost, prerequisite leverage, and staleness.
+- Order from orientation to representative decisions while avoiding clusters whose wording reveals adjacent answers.
+- Seal the confirmed mission/scope/area contract, complete normalized spec, and ordered question IDs before question 1 appears. Store the batch digest in every response and reject any cycle-contract, current-question, or future-question mutation after start.
+
+Use 3-5 options and exactly one benchmark-supported correct answer. Useful question families include recognition, mechanism, prediction, application, critique, comparison, threshold, tradeoff, counterevidence, postmortem, calibration, and sequence. Transfer belongs in Review or a later uncued check.
+
+For each question, define:
+
+- stable area, concept, kernel, question, and scenario IDs;
+- one core proposition and bounded scenario;
+- one question family;
+- one correct option and detailed explanation;
+- plausible distractors with explanations and misconception tags;
+- a neutral subdescription for every option that states a boundary, prerequisite, tradeoff, or omitted factor without signalling correctness;
+- lineage to the benchmark source.
+
+Balance option grammar, length, specificity, tone, and subdescription detail. Reserve correctness language and complete reasoning for post-commit explanations. Include `insufficient evidence; inspect X first` when action is otherwise unjustified.
+
+## 4. Run Without Rhythm Breaks
+
+The Assessment introduction presents the confirmed scope. The question view shows:
+
+- question `n / N`;
+- current area;
+- completed and remaining counts;
+- a semantic progress element.
+
+Before commitment, expose only visible copy and opaque option tokens. After commitment:
+
+1. persist the immutable response in the same transaction;
+2. lock the selection;
+3. show the selected answer and explanation;
+4. show the correct answer and explanation;
+5. offer one primary `下一題` action.
+
+Do not show a record button, a recording notice, or cumulative scores. Wrong and correct answers follow the same continuation rhythm. Refresh resumes the committed feedback state until the learner advances.
+
+## 5. Build the Assessment Report
+
+Recompute the report from server-side spec plus immutable response files. Never trust browser totals.
+
+For each area include:
+
+- answered and correct counts;
+- `穩定訊號` when area accuracy is at least 80%;
+- `混合訊號` when area accuracy is at least 50% and below 80%;
+- `待補強` when area accuracy is below 50%;
+- kernel-level gaps and misconception tags;
+- question-level traceability;
+- proposed Learning Slice targets;
+- benchmark limitations, evidence level, and confidence.
+
+Keep the status descriptive. Concept-level evidence and mission-critical blockers remain visible even when an area summary looks strong.
+
+The report also lists batch-wide strengths, unresolved prerequisites, open benchmark gaps, and the exact inputs for Learning generation.
+
+## 6. Phase Boundary
+
+Return to Codex only after the report exists. Build Learning from the completed report recomputed from immutable evidence, never from remembered browser state or an unverified report file. If the batch is incomplete, resume the same Assessment tab and immutable spec.
+
+Pause when benchmark gaps block fair scoring, fewer than ten distinct kernels exist, tool friction or fatigue distorts evidence, or the learner reaches the time box. Persist the next action without generating a partial Learning Map.

--- a/weeks/2026/2026-w35-mastery-loop/completed/mastery-loop/references/choice-interface.md
+++ b/weeks/2026/2026-w35-mastery-loop/completed/mastery-loop/references/choice-interface.md
@@ -1,0 +1,114 @@
+# Click-First Phase Interface
+
+Use this contract for goal selection and all version 3 Assessment, Learning, and Review pages.
+
+## Transport
+
+1. A native clickable control is acceptable for the three-goal gate when it returns stable IDs and does not mark a preferred answer.
+2. Use `scripts/mastery_session_ui.py` for every version 3 phase. One phase owns one loopback browser tab from its introduction through its report.
+3. When native controls are unavailable before a cycle exists, use `scripts/click_choice_ui.py` for the three-goal gate and its confirmation; navigate the same browser tab to each result. The same script also resumes historical version 1 or 2 single-question sessions.
+4. If neither click transport is available, explain the capability limit and pause. Do not request typed option codes.
+
+## Goal Gate
+
+The first interaction contains exactly three domain-adapted choices:
+
+| Stable ID | Intent | Observable outcome |
+|---|---|---|
+| `end_to_end_delivery` | End-to-end delivery | Independently produce and verify a complete result |
+| `diagnose_improve` | Diagnosis and improvement | Find failures, recover safely, and improve the workflow |
+| `review_teach` | Review and teaching | Evaluate quality, define standards, or teach the capability |
+
+After selection, show the derived outcome and clickable `確認目標`, `調整範圍`, and `暫停` actions. The Assessment introduction must then show the confirmed knowledge boundary and benchmark.
+
+## Phase State Machines
+
+```text
+Assessment:
+intro -> question -> committed feedback -> next question -> report
+
+Learning:
+map -> available slice -> completion -> next slice
+    -> area checkpoint -> checkpoint feedback -> map -> report
+
+Review:
+intro -> question -> committed feedback -> next question -> comparison report
+```
+
+Keep one primary action per state. `下一題`, `完成 Slice`, and `返回知識地圖` advance only through valid server state. A refresh restores the last committed feedback or current slice; it never silently advances.
+
+## Scored Question Contract
+
+Each question contains 3-5 mutually exclusive choices and exactly one benchmark-supported answer.
+
+Build in this order:
+
+1. state the core proposition, scenario boundary, best answer, and source;
+2. explain why the best answer satisfies the mechanism and boundary;
+3. add misconception, partial-truth, wrong-boundary, wrong-sequence, missing-evidence, or unsafe-shortcut distractors;
+4. explain precisely why each distractor fails;
+5. give every option a neutral subdescription that adds its boundary, prerequisite, tradeoff, or omitted factor;
+6. balance wording and rotate the correct-answer position;
+7. store stable IDs and correctness server-side.
+
+The subdescription supplements the option label before commitment. Use the same tone and level of detail for every option. Do not call an option correct, best, preferred, complete, aligned, passing, or full-credit; do not imply that every requirement is satisfied or that no gap remains. Do not quote hidden core propositions, post-commit explanations, future question content, stable IDs, or misconception tags. Keep correctness and full reasoning inside the post-commit explanation.
+
+- Leaking: `符合這一題的核心命題。`
+- Neutral: `只說明染色體數恢復；尚未涵蓋重組與獨立分配。`
+
+If one description is missing, repeats its label, or contains a correctness cue in a sealed historical v3 batch, suppress every description for that question so the choice surface remains balanced. Do not mutate the sealed spec or its evidence.
+
+If an introduction, title, scenario, prompt, or option label exposes an answer position, correct label, explanation, core proposition, future content, or stable internal token, refuse to serve that scored surface and return to Codex for a new phase. Those fields cannot be hidden while preserving an answerable question; keep all existing evidence unchanged.
+
+Before commitment, browser HTML and JSON may contain only the current visible prompt, visible option text, progress, and opaque random tokens. Do not expose future questions, correct status, explanations, stable option IDs, kernel IDs, misconception tags, or scoring rules.
+
+## Commit and Resume Contract
+
+Every state-changing POST carries a unique `request_id`, the current opaque item token, and the selected opaque option token where applicable.
+
+- Write the response or event before rendering success.
+- A repeated `request_id` with the same payload returns the existing result.
+- A committed question receiving the same answer under a new request ID also returns the existing result.
+- A committed question receiving a different answer returns HTTP 409.
+- Reject missing, future, stale, cross-phase, or out-of-order item tokens.
+- Derive progress, correctness, reports, and resume position from server-side specs and immutable records.
+- Keep `checkpoint.json` replaceable and reconstructable; it is navigation state, not evidence.
+
+For version 3, wrong answers are automatically persisted by the answer transaction. Do not implement or display `/record`, `記錄這個錯誤`, recording confirmation, or a close-page gate. Those behaviors remain valid only inside the unchanged legacy version 2 UI.
+
+## Learning Interaction
+
+- The map shows all area and slice positions, completed nodes, the next available node, and locked future nodes.
+- A locked node exposes only its title, position, and prerequisite relationship.
+- Completed slices remain readable.
+- Completing a slice writes an immutable event and returns to the same phase tab.
+- An area checkpoint uses the scored-question contract and saves wrong answers without blocking the next area.
+- Review generation remains unavailable until every slice and checkpoint has a completion record.
+
+## Loopback and Security Contract
+
+- Bind only to `127.0.0.1`; reject non-loopback hosts and cross-origin requests.
+- Use CSRF protection, strict content types, request body limits, path containment, HTML escaping, opaque random tokens, and constant-time token comparison where relevant.
+- Send a restrictive CSP plus `X-Frame-Options: DENY`, `X-Content-Type-Options: nosniff`, and a no-referrer policy.
+- Acquire one cycle-wide operating-system writer lock and record the owning phase. The OS releases ownership after a crash; the next server can safely reuse the persistent lock file. Join every active request handler before releasing ownership during normal shutdown.
+- Keep `validate` and pre-lock phase loading read-only. Persist reports and checkpoints only after the writable server owns the cycle lock.
+- Before announcing readiness, verify that mutable directories and reserved files have safe types and remain contained inside the cycle. Reject symbolic-link escapes and invalid parent targets.
+- Persist immutable records through same-directory temporary files, flush, `fsync`, and atomic publish.
+- Exit after phase completion or the configured inactivity timeout; every accepted local request resets that deadline.
+
+## Calm / Signal UI
+
+- Warm ivory canvas, white task surface, ink text, Purple actions, Lime result accents, semantic red and green, and thin gray rules.
+- 12px task-surface radius, 4px controls, at least 44px targets, 65-75ch reading width, and visible blue focus.
+- Use semantic `<progress>`, headings, labels, and `aria-live` feedback.
+- Support keyboard operation, responsive layouts, and `prefers-reduced-motion`.
+- Display `Created by Winston` on every introduction, question, feedback, map, slice, checkpoint, and report state.
+
+## Public CLI
+
+```powershell
+python scripts/mastery_session_ui.py validate --workspace <workspace> --cycle mastery-sessions/<cycle-id> --phase assessment|learning|review
+python scripts/mastery_session_ui.py serve --workspace <workspace> --cycle mastery-sessions/<cycle-id> --phase assessment|learning|review --port 0
+```
+
+Validate before serving. Report the generated loopback URL to the learner and reuse that tab for the entire phase.

--- a/weeks/2026/2026-w35-mastery-loop/completed/mastery-loop/references/lesson-design.md
+++ b/weeks/2026/2026-w35-mastery-loop/completed/mastery-loop/references/lesson-design.md
@@ -1,0 +1,108 @@
+# Evidence-Linked Learning Map
+
+Generate Learning only from a complete version 3 Assessment report. The result is a prerequisite-ordered knowledge map, not a loose collection of explanations.
+
+## 1. Map Construction
+
+Preserve the Assessment's 3-6 major areas. For each area:
+
+```text
+slice count = min(5 + distinct independent gap count, 10)
+```
+
+A gap is deduplicated by primary knowledge kernel. Repeated misses may raise priority but do not inflate the slice count. With 3-6 areas, the complete path contains roughly 15-60 slices.
+
+Build a directed prerequisite graph and keep difficulty non-decreasing inside each area:
+
+- start with foundations and shared vocabulary;
+- follow with mechanisms and boundaries;
+- then representative applications, tradeoffs, and failure handling;
+- end with integration and one formative area checkpoint.
+
+Reject a path with missing prerequisites, cycles, fewer than five or more than ten slices in an area, or an area without exactly one checkpoint.
+
+## 2. Slice Contract
+
+Each slice is stored separately and contains:
+
+1. stable `slice_id`, `area_id`, and positive integer `order`;
+2. title, difficulty, and prerequisite slice IDs;
+3. one observable `learning_objective`;
+4. one or more `assessment_question_ids`, plus `addresses_gap_ids` where applicable, linking relevant correct and wrong evidence;
+5. the minimum core explanation;
+6. mechanism, boundary, and failure condition;
+7. one worked example with a unique scenario fingerprint;
+8. common mistakes derived from actual misconceptions where available;
+9. a concise summary;
+10. authoritative sources or a visible provisional marker.
+
+Explain enough to support the next performance. Avoid generic motivation, repeated definitions, and content unrelated to the confirmed mission.
+
+## 3. Mapping Assessment Evidence
+
+Every proposed gap in the Assessment report must route to at least one slice, and the same slice must name that gap's source Assessment question. Every slice must name at least one related Assessment question and explain its role through one of:
+
+- a wrong Assessment kernel;
+- a prerequisite for a wrong kernel;
+- a mission-critical correct kernel that needs deeper application;
+- an integration dependency shared across areas.
+
+Show the learner these links in plain language, such as `補強：評估第 4 題` or `鞏固：評估第 7 題`. Do not label a learner globally from a single miss.
+
+Correct Assessment items may shorten explanation emphasis, but they do not remove required foundational slices. Wrong items raise the linked slice's visual priority.
+
+## 4. Progression and Access
+
+- Show the full map structure, current area, completion counts, and prerequisite connections.
+- Completed slices remain freely readable.
+- The first incomplete slice whose prerequisites are complete is the active node.
+- Locked downstream nodes reveal only title, position, and unmet prerequisite.
+- A completion action writes one immutable event. Refresh and duplicate requests return the existing event.
+- Do not infer completion from scrolling, elapsed time, or browser state.
+
+Learning progress is informational. Completing a slice does not promote mastery.
+
+## 5. Formative Area Checkpoint
+
+After all slices in an area complete, unlock exactly one checkpoint.
+
+- Use 3-5 balanced clickable options and one correct answer; each subdescription neutrally adds a boundary, prerequisite, tradeoff, or omitted factor.
+- Test a representative decision that combines the area's most important kernels.
+- Do not copy an Assessment prompt or a worked example.
+- Persist the response automatically and reveal explanations immediately.
+- A wrong response becomes a Learning gap for Review generation.
+- The learner must answer the checkpoint, but correctness does not block the next area.
+
+Record checkpoint independence as `feedback_exposed` when its kernel was taught in the same phase. Treat it as correction or application evidence, never clean baseline evidence.
+
+## 6. Learning Completion and Report
+
+Learning completes only when:
+
+- every required slice has one completion event;
+- every area checkpoint has one immutable response;
+- all event and response IDs resolve to the immutable path;
+- no prerequisite or phase lock violation remains.
+
+Build `learning/report.json` from the path, slice completion events, and checkpoint responses. Include:
+
+- completion by area;
+- Assessment gaps covered by each slice;
+- checkpoint strengths and misses;
+- kernels eligible for Review;
+- evidence limitations;
+- the complete/missing slice and checkpoint state used by the Review gate.
+
+Only a complete Learning state accepted by `ensure_review_ready` permits Review generation.
+
+## 7. Content and UI Quality
+
+- Use concise sections, semantic headings, readable line length, and clear mechanism diagrams only when they materially help.
+- Cite factual claims near the claim.
+- Keep media optional and local-first.
+- Use the Calm / Signal system, keyboard access, visible focus, responsive layout, reduced motion, and `Created by Winston`.
+- Keep the learner in one Learning tab from map introduction through the report.
+
+## 8. Evidence Boundary
+
+Reading and completion show exposure. A checkpoint can demonstrate narrow correction or application depending on task quality and independence. Transfer requires an unseen structural variant; Durable requires a delayed uncued check.

--- a/weeks/2026/2026-w35-mastery-loop/completed/mastery-loop/references/mastery-model.md
+++ b/weeks/2026/2026-w35-mastery-loop/completed/mastery-loop/references/mastery-model.md
@@ -1,0 +1,114 @@
+# Mastery Evidence Model
+
+Classify demonstrated capability per knowledge kernel. Keep mission-critical blockers visible instead of hiding them in area averages.
+
+## Evidence Levels
+
+| Code | Level | Required evidence | Insufficient evidence |
+|---|---|---|---|
+| U | Unassessed | no relevant independent evidence | exposure, confidence, credentials |
+| F | Fragile | recognition, partial recall, or one narrow correct choice | wording repeated from feedback |
+| E | Explained | mechanism, boundary, and coherent rationale | jargon or memorized definition |
+| A | Applied | correct use on a representative task with relevant constraints | copying a worked example |
+| T | Transfer | uncued correct use on an unseen structural variant | same-session correction after teaching |
+| D | Durable | delayed uncued transfer with no unresolved contradiction | any single-session result |
+
+Required level is set by the confirmed mission. End-to-end delivery normally requires simulation or artifact evidence in addition to click evidence.
+
+## Version 3 Evidence Sources
+
+### Batch Assessment
+
+- Preserve every first commitment as `independent` unless a hint was actually given.
+- Immediate feedback does not change the already-recorded baseline response.
+- Because each Assessment question has a unique kernel, later batch items must not become same-kernel feedback checks.
+- One correct item supports at most F. Several coherent items across related kernels may raise area confidence, but never promote an untested kernel.
+- Area labels summarize accuracy: `穩定訊號` at 80% or above, `混合訊號` from 50% to below 80%, and `待補強` below 50%. They are not mastery levels.
+
+### Learning
+
+- Reading a slice and marking it complete show exposure only.
+- A formative checkpoint is usually `feedback_exposed` because the area was just taught.
+- A valid checkpoint may support correction, E, or A according to its cognitive demand, but not T or D in the same session.
+
+### New-Scenario Review
+
+- A correct response shows retrieval or application after learning and may support up to A when same-session feedback is fresh.
+- Review can support T only when the scenario is a genuine unseen structural variant, the response is uncued and independent, and the spacing is sufficient to avoid direct answer carryover.
+- Review failure preserves the lower state and adds counterevidence.
+- A delayed uncued follow-up is required for D.
+
+## Click-Evidence Limits
+
+| Evidence | Maximum provisional support | Additional requirement |
+|---|---|---|
+| one correct factual choice | F | repeat uncued after spacing |
+| several coherent mechanism and boundary choices | E | vary wording and constraints |
+| representative scenario decisions | A | include failure cost and observable consequences |
+| uncued unseen structural variants | T | change the underlying context, not only names |
+| delayed unseen transfer | D | meaningful delay and no contradiction |
+
+Choice recognition cannot prove end-to-end production. Require simulation or artifact evidence for a production mission.
+
+## Independence and Feedback
+
+Use one of:
+
+- `independent`: no relevant answer, hint, or teaching was exposed before commitment;
+- `light_hint`: a direction or narrowed boundary was given;
+- `heavy_hint`: the answer structure or decisive condition was substantially supplied;
+- `copied`: the response reproduces provided material;
+- `feedback_exposed`: relevant correctness or teaching was shown earlier in the cycle;
+- `corrected`: the record explicitly links a later success to a prior miss.
+
+Preserve timing and lineage. Do not relabel a response after seeing its result.
+
+## Promotion Kernel
+
+For every proposed state change ask:
+
+1. What exact capability is claimed?
+2. What observable task would falsify it?
+3. Which immutable response, checkpoint, simulation, or artifact supports it?
+4. Was the evidence independent, hinted, copied, corrected, or feedback-exposed?
+5. Did the learner distinguish mechanism and boundary?
+6. Did performance survive a novel context?
+7. Did it survive a meaningful delay?
+
+Promote only to the highest directly supported level. Conflicting evidence keeps the lower level or lowers confidence.
+
+## Confidence
+
+- **Low**: one weak sample, ambiguous scoring, strong prompting, or provisional benchmark.
+- **Medium**: one clean representative performance or several consistent narrow samples.
+- **High**: multiple independent samples, a verified rubric, varied contexts, and no material counterevidence.
+
+Avoid numeric mastery percentages without a validated scoring model. Raw correct counts may be reported as counts.
+
+## Evidence Record
+
+```markdown
+### [Timestamp] — [Kernel]
+
+- Cycle, phase, and item ID:
+- Displayed option order:
+- Selected / correct option ID:
+- Misconception tag:
+- Scenario fingerprint:
+- Independence and feedback timing:
+- Lineage: assessment | checkpoint | review | delayed
+- Evidence level and confidence:
+- What it proves:
+- Counterevidence:
+- Next discriminating probe:
+```
+
+## Overall Claim
+
+- **Not assessed**: critical kernels remain U.
+- **Fragile**: critical evidence relies on recognition or prompting.
+- **Working**: representative applications succeed; transfer or retention remains open.
+- **Transferable**: required unseen contexts succeed independently with valid boundaries.
+- **Durable**: transferable performance survives the required delay.
+
+Always append the tested scope: `transferable for [mission/task/context]`.

--- a/weeks/2026/2026-w35-mastery-loop/completed/mastery-loop/references/quality-rubric.md
+++ b/weeks/2026/2026-w35-mastery-loop/completed/mastery-loop/references/quality-rubric.md
@@ -1,0 +1,105 @@
+# Quality Rubric
+
+Use before packaging and after any material workflow, schema, persistence, or UI change.
+
+## Version 3 Pass Criteria
+
+| Dimension | Pass condition |
+|---|---|
+| Triggering | Description routes new self-study, tutoring, capability-audit, and misconception work to version 3 while reserving legacy v1/v2 for historical resume. |
+| Goal gate | The first interaction has exactly three clickable, observable outcomes. |
+| Scope gate | Before Assessment, the learner sees the mission, 3-6 areas, inclusions, exclusions, benchmark status and sources, distribution, and estimated time. |
+| Batch validity | Assessment has 10-20 questions, at least two per area, a unique kernel per question, and exactly one supported answer per item; start seals the whole batch plus confirmed mission/scope/area contract, and every response repeats the batch digest. |
+| Click transport | Every phase remains in one loopback tab and never requires typed option codes. |
+| Pre-commit secrecy | Initial HTML and APIs expose no future item, correct status, explanation, stable option or kernel ID, misconception tag, or scoring rule. |
+| Choice descriptions | Every new option has a neutral, similarly detailed subdescription that adds a boundary, prerequisite, tradeoff, or omitted factor without correctness, position, selection, grading, completeness, or no-gap cues; sealed legacy batches suppress the whole description set when any item is missing, repeats its label, or leaks. A sealed introduction, prompt, or label that exposes server-only content is blocked without rewriting evidence. |
+| Immediate feedback | Every committed answer immediately shows the selected and correct explanations without showing cumulative score mid-batch. |
+| Automatic record | The answer transaction writes correct and wrong responses; version 3 has no record button, recording notice, or `/record` path. |
+| Progress | Question, area, completed, remaining, and semantic progress state are visible and server-derived. |
+| Assessment report | Results are recomputed from immutable records and grouped by area; stable is >=80%, mixed is >=50% and <80%, and needs support is <50%, with gaps, misconceptions, traceability, confidence, and proposed slices. |
+| Learning Map | The Assessment report produces the same 3-6 areas and 5-10 prerequisite-ordered slices per area, with non-decreasing difficulty. |
+| Slice lineage | Every slice links to at least one valid Assessment question, routes every addressed gap, explains any prerequisite/integration role, and contains the complete slice contract. |
+| Learning gates | Future nodes remain locked until prerequisites complete; every area has exactly one required checkpoint; wrong checkpoints do not block progression. |
+| Learning evidence | Reading and completion affect progress only; checkpoint evidence preserves feedback exposure. |
+| Review gate | Review remains unavailable until all slices and area checkpoints complete. |
+| Review batch | Review has 8-15 items from the gap-plus-area formula, allocates primary scoring to the capacity-prioritized gap set, includes every overflow gap as an integrated kernel, covers every area and mission-critical correct kernel, and includes cross-area integration. |
+| Review novelty | Every item preserves its primary proposition while changing scenario ID/context, fingerprint, family, prompt, all option surfaces, distractors, and correct position; trivial near-duplicates are rejected. |
+| Review lineage | One primary kernel determines scoring; integrated kernels and all Assessment/Learning sources remain traceable. |
+| Comparison report | The report distinguishes corrected, residual, overflow, newly exposed, reinforced, and cross-area results and schedules every unresolved/new gap three days after the immutable completion anchor. |
+| Evidence hygiene | First attempts, independence, feedback timing, confidence, counterevidence, and lineage remain separate. |
+| Reliability | Immutable writes are atomic; record bodies and digests are validated; validation and pre-lock loading are read-only; serve preflight validates current evidence and all reserved write targets before `ready:true`; same-selection and navigation retries are idempotent; conflicting answers return 409; invalid sequencing is rejected; the OS lock recovers after owner-process failure and stays held until live request handlers finish. |
+| Security | Loopback binding, CSRF, content and body limits, path containment, escaping, CSP, clickjacking, and opaque-token protections remain active. |
+| UI system | Calm / Signal tokens, one primary action, 44px targets, visible focus, semantic progress, reduced motion, and `Created by Winston` appear in every state. |
+| Legacy | Existing v1/v2 specs, answers, Review seeds, validator, and single-question UI still work unchanged and are never migrated. |
+| Continuity | Restart rebuilds reports and navigation from immutable records; `checkpoint.json` is disposable. |
+| Artifact routing | Version 3 accepts only the canonical six spec/report paths, so `cycle.json` declarations and persisted deliveries cannot diverge. |
+
+## Reject or Revise When
+
+- fewer than ten or more than twenty Assessment questions are accepted;
+- an area has fewer than two items or duplicate Assessment kernel IDs;
+- the knowledge boundary or benchmark status is hidden before testing;
+- an active batch or its confirmed mission, scope, benchmark, or area semantics mutates after start, or a response lacks the sealed whole-batch digest;
+- answer correctness, explanations, lineage, stable IDs, or future questions reach the pre-commit browser;
+- an introduction or option surface identifies the correct position or label, or a subdescription identifies the correct, best, complete, preferred, passing, full-credit, no-gap, or core-aligned choice, repeats its label, quotes hidden or future content, exposes a stable ID, or omits useful boundary information;
+- cumulative scores interrupt the Assessment rhythm;
+- version 3 displays a record button, recording notice, close-page gate, or `/record` route;
+- browser-supplied counts or correctness determine progress or reports;
+- area summaries hide a mission-critical failed kernel;
+- an area contains fewer than five or more than ten slices, invalid prerequisites, no checkpoint, or multiple checkpoints;
+- a slice has no Assessment evidence link, maps a gap without its source question, regresses in difficulty, or has a worked example without a scenario fingerprint;
+- scrolling, elapsed time, or client state marks a slice complete;
+- Review is generated from filenames or persisted reports without validating immutable record bodies and digests;
+- Review is generated before every Learning requirement completes;
+- Review count falls outside 8-15 or ignores the gap-plus-area formula;
+- a Review scenario repeats or trivially rewrites an Assessment, Learning checkpoint, or worked-example context;
+- a Review item changes its primary decision truth, has ambiguous primary scoring, or reuses its prompt, option label, description, or explanation surface;
+- same-session reading or correction receives Transfer or Durable status;
+- duplicate requests create multiple records, a conflicting answer overwrites history, reports unlock a phase without evidence recomputation, reserved write paths escape the cycle or have invalid types, or two phase writers operate concurrently;
+- an invalid, stale, future, or cross-phase token advances state;
+- a page omits keyboard operation, visible focus, or `Created by Winston`;
+- new-cycle documentation routes to the legacy single-question workflow;
+- historical v1/v2 files are rewritten or silently upgraded.
+- version 3 accepts a custom or unknown artifact route.
+
+## Automated Regression
+
+Run:
+
+```powershell
+python -m py_compile scripts/click_choice_ui.py scripts/init_workspace.py scripts/session_core.py scripts/mastery_session_ui.py
+python -m unittest discover -s tests -v
+python <skill-creator>/scripts/quick_validate.py <skill>
+node <impeccable>/scripts/detect.mjs --json scripts/mastery_session_ui.py
+```
+
+Verify at least:
+
+- all existing v1/v2 compatibility and record-gate tests remain green;
+- 9-item, 21-item, duplicate-ID, missing-explanation, answer-revealing, future-content, stable-ID, or empty subdescription, and insufficient-area-coverage Assessment specs are rejected before sealing;
+- a sealed historical v3 question with unsafe subdescription copy resumes without spec mutation and renders labels without any subdescription;
+- a 12-item mixed batch produces the expected area report;
+- wrong responses persist automatically and version 3 output contains no record control or notice;
+- initial HTML omits future questions, answers, explanations, stable IDs, and lineage;
+- duplicate answer, timeout retry, conflicting answer, malformed evidence timestamp, stale/future token, forged/unsealed checkpoint, restart, whole-batch future-question mutation, post-start cycle-contract mutation, invalid reserved write surfaces, full Learning contract mutation, concurrent phase-lock, active-handler shutdown, and crash-recovery cases;
+- 3 areas x 5 slices x 1 checkpoint with Assessment-source linkage, non-decreasing difficulty, prerequisite enforcement, and wrong-checkpoint continuation;
+- Review generation is blocked before full validated Learning completion and rejects empty/tampered event files;
+- 8-item Review preserves propositions and lineage while enforcing capacity-prioritized primary scoring, integrated overflow coverage, all-area/cross-area coverage, important-correct coverage, and genuinely new scenario surfaces;
+- comparison report and stable three-day delayed queue are rebuilt from the final immutable answer timestamp;
+- responsive, keyboard, focus, `aria-live`, semantic progress, reduced-motion, footer, CSP, and clickjacking behavior.
+
+## Independent Forward Test
+
+Give another agent only the skill path and a realistic mission:
+
+```markdown
+Mission: assess and teach end-to-end Agent Workflow design.
+Required scope: 3 major areas and 12 defensible kernels.
+Hidden misconceptions: partial output is treated as a complete handoff; publish timeout is retried without reconciliation.
+Required run: scope -> 12-question Assessment with mixed results -> report
+              -> 3 areas x 5+ Learning Slices and checkpoints
+              -> 8+ new-scenario Review -> comparison and delayed queue.
+Evidence boundary: reading is exposure; same-session correction is not Transfer.
+```
+
+The skill passes when the evaluator can create valid version 3 artifacts, finish each phase in one tab, conceal pre-commit data, persist responses without a record action, produce traceable reports, enforce Learning and Review gates, generate genuinely new Review contexts, preserve conservative evidence claims, and still resume a legacy v2 session.

--- a/weeks/2026/2026-w35-mastery-loop/completed/mastery-loop/references/review-loop.md
+++ b/weeks/2026/2026-w35-mastery-loop/completed/mastery-loop/references/review-loop.md
@@ -1,0 +1,129 @@
+# Integrated Review Protocol
+
+Version 3 Review converts completed Assessment and Learning evidence into one new-scenario retrieval batch. It reinforces prior errors and mission-critical ideas without repeating Assessment questions or Learning examples.
+
+## 1. Entry Gate
+
+Generate Review only when:
+
+- `assessment/report.json` is complete;
+- `learning/report.json` is complete and `ensure_review_ready` accepts the immutable event set;
+- every required slice completion and area checkpoint response exists;
+- benchmark lineage still resolves;
+- no active Assessment or Learning writer owns the cycle.
+
+Use immutable responses and reports as inputs. Do not infer gaps from browser state or memory.
+
+## 2. Select Review Coverage
+
+Deduplicate Assessment and Learning gaps by knowledge kernel while preserving every stable gap ID for lineage, then compute:
+
+```text
+question count = clamp(
+  independent Assessment and checkpoint gap-kernel count + major area count,
+  8,
+  15
+)
+```
+
+Allocate in this priority order:
+
+1. wrong Assessment kernels, weighted by mission criticality and failure cost;
+2. wrong formative checkpoint kernels;
+3. important Assessment kernels that were correct but need deeper application;
+4. cross-area combinations that test integrated judgment.
+
+Use direct-scoring capacity in this order:
+
+1. seed every gap-bearing area with its highest-priority gap;
+2. fill remaining primary slots with Assessment gaps before checkpoint gaps;
+3. within Assessment gaps, place critical gaps first;
+4. reserve one primary slot for every area that has no prior gap.
+
+When independent gaps exceed the available primary slots, include every overflow gap as an integrated kernel with complete lineage. Integrated exposure does not count as correction: keep those gap IDs unresolved and place them in delayed review. Cover every major area, include every mission-critical Assessment kernel that was answered correctly, and include at least one kernel from another area. Multiple gap records may share a primary kernel; use distinct new scenarios when the required question count needs more than one item over that kernel.
+
+## 3. Question Lineage
+
+Each Review question declares:
+
+- one `primary_kernel_id` used for scoring and comparison;
+- its unchanged `core_proposition`;
+- zero or more `integrated_kernel_ids`;
+- source Assessment and Learning item IDs;
+- a new `scenario_id` and `scenario_fingerprint`;
+- a question family, option set, explanations, and misconception tags.
+
+Integrated kernels add realistic constraints. They do not blur which primary proposition determines correctness.
+
+## 4. Novelty Contract
+
+Preserve the primary decision truth. Change all answer surfaces:
+
+- scenario ID, actors, constraints, artifacts, and scenario fingerprint;
+- question family and demanded cognitive operation;
+- prompt;
+- every option ID, label, description, and explanation;
+- distractor construction;
+- correct-answer position.
+
+The Review scenario ID, fingerprint, and context must differ from every Assessment scenario, Learning checkpoint, and Learning worked example. The deterministic validator also rejects trivial near-duplicates by normalized text similarity. Renaming actors, swapping nouns, or paraphrasing the original does not qualify, so the generator must still perform a semantic novelty review beyond the lexical check.
+
+Useful transformations:
+
+| Prior demand | Review demand | New-scenario transformation |
+|---|---|---|
+| recognition | critique | locate the same violation in a different workflow |
+| application | sequence | order recovery actions under new constraints |
+| threshold | counterevidence | identify evidence that crosses the same boundary |
+| prediction | postmortem | infer the causal failure in another domain |
+| compare | tradeoff | apply the same priority rule under a new cost profile |
+
+Every option receives detailed post-commit reasoning. The correct explanation states mechanism and boundary; each wrong explanation identifies the missing condition, wrong sequence, unsafe shortcut, or overgeneralization.
+
+Before commitment, every rewritten option description must remain neutral and supplement the label with a boundary, prerequisite, tradeoff, or omitted factor. It must not identify the correct, best, complete, or core-aligned choice.
+
+## 5. Review Interaction
+
+Use one Review tab for introduction, all 8-15 questions, and the report.
+
+- Show total and per-area progress.
+- Hide future questions, answers, explanations, stable IDs, and lineage before commitment.
+- Commit each answer automatically and immutably.
+- Show selected and correct explanations immediately.
+- Continue through one primary `下一題` action.
+- Do not show a record button or recording notice.
+
+Wrong Review responses remain gaps automatically; they do not start an immediate nested loop.
+
+## 6. Comparison Report
+
+Rebuild the report from server-side specs and immutable records. Include:
+
+- Assessment error -> correct Review correction;
+- residual Assessment or checkpoint gaps;
+- gaps reviewed through a primary kernel and overflow gaps included only as integrated constraints;
+- newly exposed Review gaps;
+- mission-critical concepts reinforced after initial success;
+- cross-area integration results;
+- evidence level, confidence, and feedback-exposure limitations;
+- source question, slice, checkpoint, and Review lineage.
+
+Schedule every residual, overflow, and newly exposed gap for an uncued review three calendar days after the immutable final Review answer. Persist that completion anchor, the due date, and the kernel list so reopening the report cannot move the schedule. End the current cycle at the report.
+
+## 7. Evidence Rules
+
+- Same-session new-scenario success usually supports correction or Applied evidence, depending on cognitive demand.
+- Transfer requires a genuine unseen structural variant, no cue, independent commitment, and sufficient spacing.
+- Durable requires a meaningful delayed uncued success.
+- A report comparison never erases the original miss; append correction evidence through lineage.
+
+## 8. Legacy Version 2 Review
+
+Historical version 2 sessions keep their original behavior:
+
+- enter from a learner-created immutable `review-records/<question-id>.json` seed;
+- preserve `knowledge_kernel_id`, `core_proposition`, `scenario_id`, and `scenario_context`;
+- change question family, prompt, every option ID and wording, distractors, and correct position;
+- require the legacy record button after a wrong response.
+
+Use `scripts/click_choice_ui.py` for that path. Do not apply the version 3 new-scenario contract to historical specs and do not migrate their records.

--- a/weeks/2026/2026-w35-mastery-loop/completed/mastery-loop/references/workspace-schema.md
+++ b/weeks/2026/2026-w35-mastery-loop/completed/mastery-loop/references/workspace-schema.md
@@ -1,0 +1,405 @@
+# Version 3 Learning Workspace
+
+The schemas in this reference match `scripts/session_core.py`. Keep specs and learner evidence immutable; keep navigation and derived reports replaceable and reconstructable.
+
+## Directory Shape
+
+```text
+learning-workspace/
+└─ mastery-sessions/
+   └─ <cycle-id>/
+      ├─ cycle.json
+      ├─ checkpoint.json
+      ├─ assessment/
+      │  ├─ spec.json
+      │  ├─ batch-manifest.json
+      │  ├─ responses/
+      │  │  └─ <question-id>.json
+      │  └─ report.json
+      ├─ learning/
+      │  ├─ path.json
+      │  ├─ slices/
+      │  │  └─ <slice-id>.json
+      │  ├─ events/
+      │  │  ├─ slice_completed.<slice-id>.json
+      │  │  └─ checkpoint_answered.<area-id>.json
+      │  └─ report.json
+      └─ review/
+         ├─ spec.json
+         ├─ batch-manifest.json
+         ├─ responses/
+         │  └─ <question-id>.json
+         └─ report.json
+```
+
+Version 3 uses the six fixed relative artifact routes shown below. Omitted keys normalize to these defaults; custom or unknown routes are rejected so declared delivery paths cannot diverge from persisted reports. Resolve and contain every path before access.
+
+## Cycle Manifest
+
+`cycle.json` supplies the canonical mission, scope, areas, and artifact routing. The JSON below abbreviates the `areas` array; a valid manifest contains 3-6 entries:
+
+```json
+{
+  "schema_version": 3,
+  "cycle_id": "agent-workflow-20260827",
+  "mission": {
+    "intent_id": "review_teach",
+    "ultimate_outcome": "Review and teach an end-to-end Agent Workflow.",
+    "audience": "Workflow designers"
+  },
+  "knowledge_scope": {
+    "title": "Agent Workflow design",
+    "direction": "Design, recover, and verify an end-to-end workflow.",
+    "includes": ["handoffs", "recovery", "acceptance evidence"],
+    "excludes": ["provider-specific pricing"],
+    "benchmark_status": "verified",
+    "sources": ["authoritative-source-id"]
+  },
+  "areas": [
+    {
+      "area_id": "handoffs",
+      "title": "Handoff contracts",
+      "description": "Typed artifacts, validation, and failure behavior.",
+      "weight": 8,
+      "failure_cost": 9,
+      "uncertainty": 6
+    }
+  ],
+  "artifacts": {
+    "assessment_spec": "assessment/spec.json",
+    "assessment_report": "assessment/report.json",
+    "learning_path": "learning/path.json",
+    "learning_report": "learning/report.json",
+    "review_spec": "review/spec.json",
+    "review_report": "review/report.json"
+  }
+}
+```
+
+Validation requires 3-6 unique `area_id` values. `mission.intent_id` is exactly one of `end_to_end_delivery`, `diagnose_improve`, or `review_teach`. `benchmark_status` is `verified`, `partially_verified`, or `provisional`; verified scope requires at least one source. `weight`, `failure_cost`, and `uncertainty` are numbers from 0 to 10.
+
+## Assessment Spec
+
+`assessment/spec.json` is sealed before the learner enters question 1. `batch-manifest.json` stores the complete normalized spec digest, the confirmed cycle-contract digest, and ordered question IDs; every response repeats the batch digest. The cycle contract covers mission, knowledge scope, and area semantics. Changing the outcome, scope, benchmark, area meaning, current question, or future question after start invalidates the batch. The JSON below shows one representative question; a valid batch contains 10-20 complete questions and 3-5 complete options per question:
+
+```json
+{
+  "schema_version": 3,
+  "phase": "assessment",
+  "cycle_id": "agent-workflow-20260827",
+  "title": "Agent Workflow Assessment",
+  "instructions": "Choose the best action for each bounded scenario.",
+  "estimated_minutes": 20,
+  "questions": [
+    {
+      "question_id": "assessment-q01",
+      "area_id": "handoffs",
+      "concept_id": "handoff-contract",
+      "knowledge_kernel_id": "handoff.explicit-assets",
+      "core_proposition": "A handoff must make required artifacts and validation explicit.",
+      "scenario_id": "content-pipeline",
+      "scenario_context": "A publisher receives text but no required image asset.",
+      "question_family": "application",
+      "title": "Missing handoff artifact",
+      "prompt": "What should happen before publishing?",
+      "sources": ["authoritative-source-id"],
+      "options": [
+        {
+          "id": "block-until-verified",
+          "label": "Block and validate the contract",
+          "description": "Applies at the pre-publication handoff boundary; post-publication monitoring remains outside this action.",
+          "explanation": "The required asset is part of the delivery contract.",
+          "misconception_tag": ""
+        }
+      ],
+      "correct_option_id": "block-until-verified",
+      "importance": 9
+    }
+  ]
+}
+```
+
+The core requires every question to carry at least one benchmark source and every wrong option to carry a non-empty misconception tag. A correct option may use an empty tag. The core computes `scenario_fingerprint` and a question digest from trusted server-side content.
+
+Assessment validation requires:
+
+- 10-20 questions;
+- the same 3-6 areas declared by `cycle.json`, each used at least twice;
+- globally unique question IDs and `knowledge_kernel_id` values;
+- 3-5 unique option IDs per question and exactly one `correct_option_id`;
+- one non-empty, neutral description per option that adds a boundary, prerequisite, tradeoff, or omitted factor without correctness, selection, grading, completeness, or no-gap cues and without repeating the label; introductions, labels, and descriptions cannot quote hidden explanations, future question or option surfaces, stable IDs, or misconception tags;
+- an explanation for every option;
+- supported question family, bounded scenario, and importance from 0 to 10.
+
+The initial browser receives only current visible copy, progress, and opaque tokens.
+
+## Immutable Assessment and Review Response
+
+```json
+{
+  "schema_version": 3,
+  "record_type": "question_response",
+  "phase": "assessment",
+  "cycle_id": "agent-workflow-20260827",
+  "question_id": "assessment-q01",
+  "batch_spec_digest": "sha256...",
+  "question_digest": "sha256...",
+  "area_id": "handoffs",
+  "concept_id": "handoff-contract",
+  "knowledge_kernel_id": "handoff.explicit-assets",
+  "primary_kernel_id": null,
+  "integrated_kernel_ids": [],
+  "scenario_id": "content-pipeline",
+  "scenario_fingerprint": "sha256...",
+  "question_family": "application",
+  "lineage": {},
+  "displayed_option_order": ["...", "...", "..."],
+  "selected_option_id": "...",
+  "selected_misconception_tag": "...",
+  "correct_option_id": "block-until-verified",
+  "is_correct": false,
+  "independence": "independent",
+  "feedback_exposed": false,
+  "feedback_timing": "immediate_after_commit",
+  "request_id": "opaque-idempotency-id",
+  "answered_at": "RFC-3339 timestamp"
+}
+```
+
+Assessment records use `independent`; Review records use `feedback_exposed`. Correctness is recomputed against the immutable spec and is never supplied by the browser. For Review, `knowledge_kernel_id` aliases `primary_kernel_id`, and lineage contains source Assessment, slice, and checkpoint IDs.
+
+Write one response per question. Repeating the same selection returns the existing record even under a new `request_id`. A different later selection returns HTTP 409 and never overwrites history. Missing or mismatched batch manifests and response-level batch digests invalidate progress and report generation.
+
+## Assessment Report
+
+`assessment/report.json` is rebuilt from the validated spec and response files. It contains batch completion counts, question results, gaps, critical gaps, evidence limitations, and per-area:
+
+- answered, total, correct, and accuracy;
+- `stable_signal` / `穩定訊號` at accuracy >= 0.80;
+- `mixed_signal` / `混合訊號` at accuracy >= 0.50 and < 0.80;
+- `needs_support` / `待補強` below 0.50;
+- gap and critical-gap IDs;
+- `suggested_slice_count = min(10, 5 + distinct area gap count)`;
+- confidence.
+
+A wrong item creates a stable gap ID such as `assessment.assessment-q01`. Importance 8 or above marks the gap critical. Reports may be atomically regenerated; evidence files remain unchanged.
+
+## Learning Path
+
+`learning/path.json` embeds the complete trusted checkpoint question for each area. The example abbreviates the full 3-6 area array:
+
+```json
+{
+  "schema_version": 3,
+  "phase": "learning",
+  "cycle_id": "agent-workflow-20260827",
+  "title": "Agent Workflow Learning Map",
+  "areas": [
+    {
+      "area_id": "handoffs",
+      "title": "Handoff contracts",
+      "slice_ids": [
+        "handoffs-01",
+        "handoffs-02",
+        "handoffs-03",
+        "handoffs-04",
+        "handoffs-05"
+      ],
+      "checkpoint": {
+        "question_id": "handoffs-checkpoint",
+        "area_id": "handoffs",
+        "concept_id": "handoff-integration",
+        "knowledge_kernel_id": "handoff.integrated-check",
+        "core_proposition": "Required artifacts must pass their handoff contract.",
+        "scenario_id": "handoff-checkpoint",
+        "scenario_context": "A new workflow hands off several required artifacts.",
+        "question_family": "critique",
+        "title": "Area checkpoint",
+        "prompt": "Which defect blocks continuation?",
+        "sources": ["authoritative-source-id"],
+        "options": ["3-5 complete option objects"],
+        "correct_option_id": "one-option-id",
+        "importance": 8
+      }
+    }
+  ]
+}
+```
+
+Learning areas must exactly match `cycle.json`. Slice IDs are globally unique. Each area has 5-10 slices and one checkpoint belonging to that area; checkpoint kernel IDs and question IDs are globally unique and cannot collide with Assessment kernel or question IDs. Every slice names at least one Assessment question, and every link resolves to a real Assessment question ID. The path becomes immutable after its first Learning event.
+
+## Learning Slice
+
+Each `learning/slices/<slice-id>.json` uses:
+
+```json
+{
+  "schema_version": 3,
+  "slice_id": "handoffs-01",
+  "area_id": "handoffs",
+  "title": "Explicit handoff assets",
+  "order": 1,
+  "difficulty": "foundation",
+  "prerequisites": [],
+  "learning_objective": "Identify every artifact required by a handoff.",
+  "assessment_question_ids": ["assessment-q01"],
+  "addresses_gap_ids": ["assessment.assessment-q01"],
+  "core_explanation": "...",
+  "mechanism": "...",
+  "boundaries": ["..."],
+  "worked_example": {
+    "scenario_id": "handoff-example-01",
+    "scenario_context": "A different bounded example.",
+    "walkthrough": "..."
+  },
+  "common_mistakes": ["..."],
+  "key_takeaways": ["..."],
+  "sources": ["authoritative-source-id"]
+}
+```
+
+`difficulty` is `foundation`, `core`, or `advanced` and must be non-decreasing inside each area. The core derives the worked-example fingerprint. Slice order must match its position in the area's `slice_ids`; every prerequisite must resolve to an earlier slice. Every Assessment gap must appear in at least one `addresses_gap_ids` entry, and that slice must also include the gap's `source_question_id` in `assessment_question_ids`. When an Assessment report is supplied, each area's slice count must equal its `suggested_slice_count`.
+
+## Learning Events and Report
+
+Slice completion is write-once:
+
+```json
+{
+  "schema_version": 3,
+  "record_type": "learning_event",
+  "event_type": "slice_completed",
+  "cycle_id": "agent-workflow-20260827",
+  "slice_id": "handoffs-01",
+  "area_id": "handoffs",
+  "learning_contract_digest": "sha256...",
+  "slice_digest": "sha256...",
+  "request_id": "opaque-idempotency-id",
+  "completed_at": "RFC-3339 timestamp",
+  "mastery_effect": "progress_only"
+}
+```
+
+A slice event is accepted only when it is the next node in the validated event sequence and every prerequisite completes. The slice digest binds the event to that normalized Slice; `learning_contract_digest` binds it to the complete path plus all ordered Slice files, so changing unfinished content after the first event invalidates the phase. The area checkpoint unlocks only after all area slices complete. Its `checkpoint_answered.<area-id>.json` event stores the same contract digest plus the trusted question digest, kernel, option order, selection, misconception, correctness, immediate-feedback timing, request ID, and timestamp. Empty, malformed, unexpected, out-of-order, or digest-mismatched event files are rejected.
+
+`learning/report.json` contains:
+
+- complete, completed/missing slice IDs and counts;
+- completed/missing checkpoint area IDs and counts;
+- checkpoint results and Learning gap records;
+- `mastery_effect: "learning_progress_only"`;
+- generation time.
+
+`ensure_review_ready` validates every event body and permits Review only when no slice or checkpoint is missing. Learning and Review loaders rebuild upstream reports from the immutable specs, responses, and validated events; persisted report files never unlock a later phase by themselves.
+
+## Review Spec
+
+`review/spec.json` uses the Assessment batch header plus 8-15 Review questions. The example shows one representative item:
+
+```json
+{
+  "schema_version": 3,
+  "phase": "review",
+  "cycle_id": "agent-workflow-20260827",
+  "title": "Integrated Review",
+  "instructions": "Apply the learned kernels in new scenarios.",
+  "questions": [
+    {
+      "question_id": "review-q01",
+      "area_id": "handoffs",
+      "concept_id": "handoff-contract",
+      "primary_kernel_id": "handoff.explicit-assets",
+      "integrated_kernel_ids": ["recovery.reconcile-state"],
+      "source_question_id": "assessment-q01",
+      "core_proposition": "Copy the source proposition exactly.",
+      "scenario_id": "refund-webhook",
+      "scenario_context": "A new domain with the same decision structure.",
+      "question_family": "sequence",
+      "title": "New-scenario review",
+      "prompt": "Which sequence is valid?",
+      "sources": ["authoritative-source-id"],
+      "options": ["3-5 complete new option objects"],
+      "correct_option_id": "new-option-id",
+      "importance": 9,
+      "lineage": {
+        "assessment_question_ids": ["assessment-q01"],
+        "learning_slice_ids": ["handoffs-01"],
+        "learning_checkpoint_ids": []
+      }
+    }
+  ]
+}
+```
+
+The core derives scenario fingerprints and validates:
+
+- question count equals `clamp(distinct Assessment/Learning gap-kernel count + area count, 8, 15)`;
+- capacity-prioritized gap kernels appear as primary scoring kernels: seed each gap-bearing area from its highest-priority gap, then fill with Assessment gaps before checkpoint gaps and critical Assessment gaps before other Assessment gaps;
+- every overflow gap beyond direct-scoring capacity appears as an integrated kernel with complete lineage and remains unresolved for delayed review;
+- `primary_kernel_id`, `area_id`, and `source_question_id` agree and preserve the exact core proposition;
+- all integrated kernels resolve;
+- every major area is covered, at least one question integrates a kernel from another area, and every mission-critical correct Assessment kernel is included;
+- scenario ID and fingerprint are new, and deterministic near-duplicate screening rejects trivial rewrites of prior contexts;
+- question family, normalized prompt, all option IDs, labels, descriptions, explanations, and correct-answer position differ from the source;
+- Review fingerprints are unique and do not match any Assessment scenario, Learning checkpoint, or Learning worked example;
+- lineage includes the primary source plus the Assessment or checkpoint source for every integrated kernel, and names only known Assessment, Slice, and checkpoint IDs.
+
+## Review Report
+
+`review/report.json` is derived from the Review spec, responses, Assessment report, and Learning report. It contains:
+
+- question results with primary/integrated kernels and prior gap IDs;
+- `corrected_gap_ids`;
+- `remaining_gap_ids`;
+- `directly_reviewed_gap_ids` and `not_directly_reviewed_gap_ids`;
+- `new_errors`;
+- `reinforced_concepts`;
+- `delayed_review` entries for residual and new gaps;
+- missing question IDs and completion counts.
+
+Each delayed entry uses the gap ID, `due_date` three calendar days after the immutable final Review response timestamp, and `mode: "uncued"`. `completion_anchor` records that timestamp, so report regeneration on a later day cannot move the due date. The report closes the current cycle; it does not start an immediate nested loop.
+
+## Checkpoint, Persistence, and Locking
+
+`checkpoint.json` is reconstructable navigation only, for example:
+
+```json
+{
+  "schema_version": 3,
+  "cycle_id": "agent-workflow-20260827",
+  "phase": "assessment",
+  "screen": "feedback",
+  "index": 0,
+  "subject_id": "assessment-q01",
+  "updated_at": "RFC-3339 timestamp",
+  "evidence_source": false
+}
+```
+
+- Treat checkpoint as a cache and rebuild it from specs and immutable records when stale, missing, or corrupt.
+- Acquire the cycle-wide operating-system lock through `.cycle.lock` before serving any writable phase; record active/released state and reject every second writer. OS lock ownership is released automatically after process failure, so a restart can safely recover without deleting lock evidence. The server joins every live request handler before releasing this lock.
+- Publish immutable evidence once through flushed, synced, atomic same-directory operations that never replace an existing target.
+- Publish the batch manifest once; replace only derived reports and checkpoint through a flushed same-directory temporary file and atomic rename.
+- Before `ready:true`, require `responses/` or `events/` to be a contained directory or absent, and require manifest, checkpoint, report, and lock targets to be contained regular files or absent. Reject symbolic-link escapes, traversal, out-of-cycle artifact paths, stale/future/cross-phase tokens, and spec/record digest mismatches.
+- Treat an unsealed question checkpoint as invalid. If a manifest was sealed before a crash and no answer exists yet, resume at question 1 without resealing or exposing a future item.
+- Recompute progress and reports after restart from immutable records. CLI validation and phase loading keep recomputed upstream reports in memory; a server validates current phase evidence after acquiring the lock and before printing `ready:true`. Persist a report only while the cycle lock is held at its phase-completion transaction.
+
+## Legacy Compatibility
+
+Keep the existing root-level version 1 and 2 workspace readable:
+
+```text
+MISSION.md
+KNOWLEDGE-MAP.md
+MASTERY.md
+choice-sessions/
+review-records/
+assessment-records/
+learning-records/
+lessons/
+```
+
+- Missing `schema_version` remains version 1.
+- Existing version 2 specs, answers, and learner-created Review seeds remain unchanged.
+- Use `scripts/click_choice_ui.py` for legacy validation and serving.
+- Never silently import or rewrite legacy evidence inside a version 3 cycle.

--- a/weeks/2026/2026-w35-mastery-loop/completed/mastery-loop/scripts/click_choice_ui.py
+++ b/weeks/2026/2026-w35-mastery-loop/completed/mastery-loop/scripts/click_choice_ui.py
@@ -1,0 +1,828 @@
+#!/usr/bin/env python3
+"""Serve one mouse-first Mastery Loop question with immediate feedback.
+
+The server binds to loopback, records one committed answer without overwrite,
+and keeps a wrong-answer page alive until the learner explicitly records the
+mistake as a Review seed. It uses only the Python standard library.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import html
+import json
+import os
+import re
+import secrets
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from typing import Any
+
+
+QUESTION_ID_RE = re.compile(r"^[a-z0-9][a-z0-9._-]{0,127}$")
+KINDS = {"intent", "knowledge", "action", "confirmation"}
+MODES = {"learn", "audit", "review"}
+QUESTION_FAMILIES = {
+    "recognition",
+    "explanation",
+    "prediction",
+    "application",
+    "critique",
+    "compare",
+    "threshold",
+    "tradeoff",
+    "transfer",
+    "counterevidence",
+    "postmortem",
+    "calibration",
+    "sequence",
+}
+MODE_LABELS = {"learn": "學習", "audit": "評估", "review": "複習"}
+KIND_LABELS = {
+    "intent": "目標選擇",
+    "knowledge": "知識檢核",
+    "action": "下一步",
+    "confirmation": "確認",
+}
+
+
+class SpecError(ValueError):
+    """Raised when a question specification violates the click contract."""
+
+
+def utc_now() -> str:
+    return dt.datetime.now(dt.timezone.utc).isoformat()
+
+
+def resolve_within(root: Path, candidate: Path) -> Path:
+    root = root.resolve()
+    resolved = candidate.resolve()
+    try:
+        resolved.relative_to(root)
+    except ValueError as exc:
+        raise SpecError(f"Path must stay inside workspace: {resolved}") from exc
+    return resolved
+
+
+def nonempty_string(value: Any, field: str, maximum: int) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise SpecError(f"{field} must be a non-empty string")
+    value = value.strip()
+    if len(value) > maximum:
+        raise SpecError(f"{field} exceeds {maximum} characters")
+    return value
+
+
+def optional_string(value: Any, field: str, maximum: int) -> str:
+    if value in (None, ""):
+        return ""
+    if not isinstance(value, str):
+        raise SpecError(f"{field} must be a string")
+    value = value.strip()
+    if len(value) > maximum:
+        raise SpecError(f"{field} exceeds {maximum} characters")
+    return value
+
+
+def validate_spec(data: dict[str, Any]) -> dict[str, Any]:
+    schema_version = data.get("schema_version", 1)
+    if schema_version not in {1, 2}:
+        raise SpecError("schema_version must be 1 or 2")
+
+    question_id = nonempty_string(data.get("question_id"), "question_id", 128)
+    if not QUESTION_ID_RE.fullmatch(question_id):
+        raise SpecError("question_id contains unsupported characters")
+
+    kind = data.get("kind")
+    if kind not in KINDS:
+        raise SpecError(f"kind must be one of: {', '.join(sorted(KINDS))}")
+    mode = data.get("mode", "learn")
+    if mode not in MODES:
+        raise SpecError(f"mode must be one of: {', '.join(sorted(MODES))}")
+    if mode == "review" and schema_version < 2:
+        raise SpecError("review questions require schema_version 2")
+
+    title = nonempty_string(data.get("title"), "title", 120)
+    prompt = nonempty_string(data.get("prompt"), "prompt", 1200)
+    concept_id = optional_string(data.get("concept_id"), "concept_id", 128)
+    kernel_id = optional_string(
+        data.get("knowledge_kernel_id"), "knowledge_kernel_id", 128
+    )
+    scenario_id = optional_string(data.get("scenario_id"), "scenario_id", 128)
+    core_proposition = optional_string(
+        data.get("core_proposition"), "core_proposition", 1200
+    )
+    scenario_context = optional_string(
+        data.get("scenario_context"), "scenario_context", 1200
+    )
+    question_family = optional_string(
+        data.get("question_family"), "question_family", 64
+    )
+    review_of = optional_string(data.get("review_of"), "review_of", 128)
+
+    if question_family and question_family not in QUESTION_FAMILIES:
+        raise SpecError(
+            f"question_family must be one of: {', '.join(sorted(QUESTION_FAMILIES))}"
+        )
+    for field_name, field_value in (
+        ("concept_id", concept_id),
+        ("knowledge_kernel_id", kernel_id),
+        ("scenario_id", scenario_id),
+        ("review_of", review_of),
+    ):
+        if field_value and not QUESTION_ID_RE.fullmatch(field_value):
+            raise SpecError(f"{field_name} contains unsupported characters")
+
+    if kind == "knowledge" and schema_version >= 2:
+        required = {
+            "concept_id": concept_id,
+            "knowledge_kernel_id": kernel_id,
+            "scenario_id": scenario_id,
+            "core_proposition": core_proposition,
+            "scenario_context": scenario_context,
+            "question_family": question_family,
+        }
+        missing = [name for name, value in required.items() if not value]
+        if missing:
+            raise SpecError(
+                "version 2 knowledge questions require: " + ", ".join(missing)
+            )
+    if kind != "knowledge" and any(
+        (concept_id, kernel_id, scenario_id, core_proposition, scenario_context, review_of)
+    ):
+        raise SpecError("Knowledge metadata is only valid for kind: knowledge")
+    if mode == "review" and not review_of:
+        raise SpecError("review questions require review_of")
+    if mode != "review" and review_of:
+        raise SpecError("review_of is only valid in review mode")
+
+    options = data.get("options")
+    if not isinstance(options, list):
+        raise SpecError("options must be an array")
+    if kind == "intent" and len(options) != 3:
+        raise SpecError("intent questions require exactly 3 options")
+    if kind == "knowledge" and not 3 <= len(options) <= 5:
+        raise SpecError("knowledge questions require 3 to 5 options")
+    if kind in {"action", "confirmation"} and not 2 <= len(options) <= 5:
+        raise SpecError("action and confirmation questions require 2 to 5 options")
+
+    cleaned_options: list[dict[str, str]] = []
+    option_ids: set[str] = set()
+    for index, option in enumerate(options):
+        if not isinstance(option, dict):
+            raise SpecError(f"options[{index}] must be an object")
+        option_id = nonempty_string(option.get("id"), f"options[{index}].id", 128)
+        if not QUESTION_ID_RE.fullmatch(option_id):
+            raise SpecError(f"options[{index}].id contains unsupported characters")
+        if option_id in option_ids:
+            raise SpecError(f"Duplicate option id: {option_id}")
+        option_ids.add(option_id)
+        explanation = optional_string(
+            option.get("explanation"), f"options[{index}].explanation", 1600
+        )
+        if kind == "knowledge" and schema_version >= 2 and not explanation:
+            raise SpecError(
+                f"options[{index}].explanation is required for version 2 knowledge questions"
+            )
+        cleaned_options.append(
+            {
+                "id": option_id,
+                "label": nonempty_string(
+                    option.get("label"), f"options[{index}].label", 240
+                ),
+                "description": optional_string(
+                    option.get("description"), f"options[{index}].description", 600
+                ),
+                "explanation": explanation,
+                "misconception_tag": optional_string(
+                    option.get("misconception_tag"),
+                    f"options[{index}].misconception_tag",
+                    120,
+                ),
+            }
+        )
+
+    correct = data.get("correct_option_ids", [])
+    if not isinstance(correct, list) or any(not isinstance(item, str) for item in correct):
+        raise SpecError("correct_option_ids must be an array of option IDs")
+    if len(set(correct)) != len(correct):
+        raise SpecError("correct_option_ids contains duplicates")
+    unknown_correct = set(correct) - option_ids
+    if unknown_correct:
+        raise SpecError(f"Unknown correct option IDs: {sorted(unknown_correct)}")
+    if kind == "knowledge" and len(correct) != 1:
+        raise SpecError("single-select knowledge questions require exactly 1 correct option")
+    if kind != "knowledge" and correct:
+        raise SpecError("Only knowledge questions may define correct_option_ids")
+
+    return {
+        "schema_version": schema_version,
+        "question_id": question_id,
+        "kind": kind,
+        "mode": mode,
+        "title": title,
+        "prompt": prompt,
+        "concept_id": concept_id,
+        "knowledge_kernel_id": kernel_id,
+        "scenario_id": scenario_id,
+        "core_proposition": core_proposition,
+        "scenario_context": scenario_context,
+        "question_family": question_family,
+        "review_of": review_of,
+        "options": cleaned_options,
+        "correct_option_ids": correct,
+    }
+
+
+def review_record_path_for(workspace: Path, question_id: str) -> Path:
+    directory = workspace / "review-records"
+    directory.mkdir(parents=True, exist_ok=True)
+    return resolve_within(workspace, directory / f"{question_id}.json")
+
+
+def answer_path_for(workspace: Path, question_id: str) -> Path:
+    directory = workspace / "choice-sessions"
+    directory.mkdir(parents=True, exist_ok=True)
+    return resolve_within(workspace, directory / f"{question_id}.answer.json")
+
+
+def read_json(path: Path) -> dict[str, Any]:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise SpecError(f"Expected an object in {path}")
+    return data
+
+
+def normalize_text(value: str) -> str:
+    return " ".join(value.casefold().split())
+
+
+def validate_review_source(workspace: Path, spec: dict[str, Any]) -> None:
+    if spec["mode"] != "review":
+        return
+    source_path = review_record_path_for(workspace, spec["review_of"])
+    if not source_path.is_file():
+        raise SpecError(f"Review source not found: {source_path}")
+    try:
+        source = read_json(source_path)
+    except (OSError, json.JSONDecodeError) as exc:
+        raise SpecError(f"Invalid review source: {source_path}") from exc
+    if source.get("record_type") != "review_seed":
+        raise SpecError("review_of must point to a review_seed record")
+    for field in (
+        "knowledge_kernel_id",
+        "scenario_id",
+        "core_proposition",
+        "scenario_context",
+    ):
+        if spec[field] != source.get(field):
+            raise SpecError(f"Review must preserve source {field}")
+    if spec["question_family"] == source.get("source_question_family"):
+        raise SpecError("Review must change question_family")
+    if normalize_text(spec["prompt"]) == normalize_text(str(source.get("source_prompt", ""))):
+        raise SpecError("Review must change the prompt")
+    source_ids = {str(item.get("id")) for item in source.get("source_options", [])}
+    new_ids = {item["id"] for item in spec["options"]}
+    if source_ids & new_ids:
+        raise SpecError("Review must use new option IDs")
+    source_labels = {
+        normalize_text(str(item.get("label", ""))) for item in source.get("source_options", [])
+    }
+    new_labels = {normalize_text(item["label"]) for item in spec["options"]}
+    if source_labels & new_labels:
+        raise SpecError("Review must rewrite every option label")
+    source_misconception = str(
+        source.get("selected_option", {}).get("misconception_tag") or ""
+    )
+    if source_misconception:
+        new_wrong_tags = {
+            item["misconception_tag"]
+            for item in spec["options"]
+            if item["id"] not in spec["correct_option_ids"]
+        }
+        if source_misconception not in new_wrong_tags:
+            raise SpecError("Review must re-probe the recorded misconception tag")
+    source_position = source.get("source_correct_position")
+    new_position = spec["correct_option_ids"] and [
+        item["id"] for item in spec["options"]
+    ].index(spec["correct_option_ids"][0])
+    if source_position == new_position:
+        raise SpecError("Review must rotate the correct-option position")
+
+
+def load_spec(workspace: Path, spec_arg: str) -> tuple[Path, dict[str, Any]]:
+    candidate = Path(spec_arg)
+    if not candidate.is_absolute():
+        candidate = workspace / candidate
+    spec_path = resolve_within(workspace, candidate)
+    if not spec_path.is_file():
+        raise SpecError(f"Spec file not found: {spec_path}")
+    try:
+        data = json.loads(spec_path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise SpecError(f"Invalid JSON: {exc}") from exc
+    if not isinstance(data, dict):
+        raise SpecError("Spec root must be an object")
+    spec = validate_spec(data)
+    validate_review_source(workspace, spec)
+    return spec_path, spec
+
+
+STYLE = """
+:root{color-scheme:light;--ivory:#F1EFE7;--ink:#111111;--purple:#7432FF;--purple-dark:#5B20E6;--lime:#DFF813;--white:#FFFFFF;--gray-100:#EAE9E2;--gray-300:#C9C8C1;--gray-600:#6B6B68;--focus:#1877F2;--success:#18A76B;--error:#DB1B1B;--shadow:0 8px 24px rgba(17,17,17,.12);--display:"Italiana","Iowan Old Style",Georgia,serif;--body:"Noto Sans TC","PingFang TC","Microsoft JhengHei","Segoe UI",sans-serif;--signal:"Roboto Condensed","Arial Narrow","Noto Sans TC",sans-serif}
+*{box-sizing:border-box}html{background:var(--ivory)}body{margin:0;min-height:100vh;background:var(--ivory);color:var(--ink);font-family:var(--body);-webkit-font-smoothing:antialiased}.page{min-height:100vh;display:flex;flex-direction:column}.masthead{width:min(960px,calc(100% - 32px));margin:0 auto;padding:24px 0 16px;display:flex;align-items:baseline;justify-content:space-between;gap:16px;border-bottom:1px solid var(--gray-300)}.brand{margin:0;font-family:var(--display);font-size:28px;line-height:1;letter-spacing:-.025em}.mode{font-family:var(--signal);font-size:13px;font-weight:700;letter-spacing:.04em;color:var(--gray-600)}.stage{width:min(760px,calc(100% - 32px));margin:auto;padding:48px 0 64px}.sheet{background:var(--white);border:1px solid var(--gray-300);border-radius:12px;padding:clamp(24px,5vw,48px);box-shadow:var(--shadow)}.kicker{margin:0 0 8px;color:var(--purple);font-family:var(--signal);font-size:14px;font-weight:800;letter-spacing:.025em}h1{margin:0 0 16px;max-width:18ch;font-size:clamp(30px,6vw,52px);line-height:1.05;letter-spacing:-.03em;text-wrap:balance}h2{margin:0 0 8px;font-size:20px;line-height:1.3;letter-spacing:-.015em}.prompt{margin:0 0 32px;max-width:72ch;color:#3e3e3b;font-size:18px;line-height:1.7}.choice-list{border:1px solid var(--gray-300);border-radius:7px;overflow:hidden;background:var(--white)}.option{appearance:none;width:100%;min-height:72px;display:flex;align-items:center;justify-content:space-between;gap:16px;padding:16px;text-align:left;color:var(--ink);background:var(--white);border:0;border-bottom:1px solid var(--gray-100);border-radius:0;cursor:pointer;transition:background-color 180ms ease-out,box-shadow 180ms ease-out}.option:last-child{border-bottom:0}.option:hover{background:#faf8ff}.option[aria-pressed="true"]{color:var(--ink);background:#f3eeff;box-shadow:inset 0 0 0 2px var(--purple)}.choice-copy{display:grid;gap:4px}.label{font-size:17px;font-weight:760;line-height:1.4}.description{color:var(--gray-600);font-size:14px;line-height:1.55}.option[aria-pressed="true"] .description{color:#3e3e3b}.choice-mark{flex:0 0 24px;width:24px;height:24px;display:grid;place-items:center;border:1px solid currentColor;border-radius:50%;opacity:.36;font-weight:900}.option[aria-pressed="true"] .choice-mark{color:var(--ink);background:var(--lime);border-color:var(--purple);opacity:1}.actions{display:flex;justify-content:flex-end;margin-top:24px}.primary{min-height:48px;padding:12px 20px;border:0;border-radius:4px;background:var(--purple);color:var(--white);font-family:var(--body);font-size:15px;font-weight:800;cursor:pointer;transition:background-color 180ms ease-out,transform 180ms ease-out,box-shadow 180ms ease-out}.primary:hover{background:var(--purple-dark);transform:translateY(-1px);box-shadow:0 6px 16px rgba(91,32,230,.2)}.primary:disabled{cursor:not-allowed;opacity:.45;transform:none;box-shadow:none}.primary.record{width:100%}.status{min-height:24px;margin:12px 0 0;color:var(--gray-600);font-size:14px;line-height:1.5}.result-band{margin:-48px -48px 32px;padding:32px 48px 28px;border-radius:12px 12px 0 0;background:var(--lime);color:var(--ink)}.result-band.error{background:#fff4f4;color:var(--ink);border-bottom:1px solid var(--error)}.result-band.error .result-label{color:var(--error)}.result-label{margin:0 0 8px;font-family:var(--signal);font-size:14px;font-weight:800}.result-band h1{margin:0;max-width:none}.answer-section{display:grid;gap:0;margin:24px 0;border-top:1px solid var(--gray-300);border-bottom:1px solid var(--gray-300)}.answer-row{padding:20px 0}.answer-row+.answer-row{border-top:1px solid var(--gray-100)}.answer-tag{margin:0 0 8px;color:var(--gray-600);font-family:var(--signal);font-size:13px;font-weight:800}.answer-row.wrong .answer-tag{color:var(--error)}.answer-row.correct .answer-tag{color:var(--success)}.answer-title{margin:0 0 8px;font-size:18px;font-weight:800;line-height:1.45}.explanation{margin:0;max-width:72ch;color:#3e3e3b;font-size:16px;line-height:1.75}.core{margin:24px 0;padding:16px;background:var(--ivory);border-radius:7px;color:#343431;font-size:14px;line-height:1.65}.next{margin:24px 0 0;padding-top:20px;border-top:1px solid var(--gray-300);color:var(--gray-600);font-size:15px;line-height:1.65}.record-copy{margin:0 0 16px;color:#3e3e3b;font-size:15px;line-height:1.65}.footer{width:min(960px,calc(100% - 32px));margin:0 auto;padding:24px 16px;border-top:1px solid var(--gray-300);color:var(--gray-600);font-size:12px;text-align:center}.wordmark{font-family:var(--display);font-size:14px;color:var(--ink)}button:focus-visible{outline:3px solid var(--focus);outline-offset:2px}
+@media(max-width:640px){.masthead{padding-top:18px}.stage{padding:28px 0 40px}.sheet{padding:24px 20px}.result-band{margin:-24px -20px 24px;padding:24px 20px 22px}.prompt{font-size:16px}.option{min-height:68px;padding:14px}.actions,.primary{width:100%}}
+@media(prefers-reduced-motion:reduce){*,*::before,*::after{scroll-behavior:auto!important;transition-duration:.01ms!important;animation-duration:.01ms!important;animation-iteration-count:1!important}}
+"""
+
+
+def render_page(title: str, mode: str, body: str, script: str = "") -> str:
+    script_markup = "<script>(()=>{" + script + "})();</script>" if script else ""
+    return (
+        '<!doctype html><html lang="zh-Hant"><head><meta charset="utf-8">'
+        '<meta name="viewport" content="width=device-width,initial-scale=1">'
+        f"<title>{html.escape(title)}</title><style>{STYLE}</style></head><body>"
+        '<div class="page"><header class="masthead"><p class="brand">Mastery Loop</p>'
+        f'<span class="mode">{html.escape(MODE_LABELS.get(mode, mode))}</span></header>'
+        f'<div class="stage">{body}</div>'
+        '<footer class="footer" aria-label="Created by Winston"><span>Created by </span><span class="wordmark">Winston</span></footer></div>'
+        f"{script_markup}</body></html>"
+    )
+
+
+def render_question(
+    spec: dict[str, Any], csrf_token: str, browser_options: dict[str, dict[str, str]]
+) -> str:
+    option_markup = []
+    for token, option in browser_options.items():
+        description = ""
+        if option["description"]:
+            description = f'<span class="description">{html.escape(option["description"])}</span>'
+        option_markup.append(
+            '<button class="option" type="button" aria-pressed="false" '
+            f'data-option-token="{html.escape(token, quote=True)}">'
+            '<span class="choice-copy">'
+            f'<span class="label">{html.escape(option["label"])}</span>{description}'
+            '</span><span class="choice-mark" aria-hidden="true">✓</span></button>'
+        )
+    body = (
+        '<main class="sheet">'
+        f'<p class="kicker">{html.escape(KIND_LABELS[spec["kind"]])}</p>'
+        f'<h1>{html.escape(spec["title"])}</h1>'
+        f'<p class="prompt">{html.escape(spec["prompt"])}</p>'
+        f'<section class="choice-list" aria-label="可選項目">{"".join(option_markup)}</section>'
+        '<div class="actions"><button class="primary" id="commit" type="button" disabled>提交答案</button></div>'
+        '<p class="status" id="status" role="status" aria-live="polite"></p></main>'
+    )
+    script = """
+const token=__TOKEN__;const buttons=[...document.querySelectorAll('.option')];
+const commit=document.querySelector('#commit');const status=document.querySelector('#status');let selected=null;
+for(const button of buttons){button.addEventListener('click',()=>{selected=button.dataset.optionToken;for(const item of buttons)item.setAttribute('aria-pressed',String(item===button));commit.disabled=false;status.textContent='';});}
+commit.addEventListener('click',async()=>{if(!selected)return;commit.disabled=true;status.textContent='正在提交並整理解析…';try{const response=await fetch('/answer',{method:'POST',headers:{'Content-Type':'application/json','X-Choice-Token':token},body:JSON.stringify({option_token:selected})});if(!response.ok)throw new Error(await response.text());const nextPage=await response.text();document.open();document.write(nextPage);document.close();}catch(error){status.textContent='提交失敗。請保留此頁，回到 Codex 後再試一次。';commit.disabled=false;}});
+""".replace("__TOKEN__", json.dumps(csrf_token))
+    return render_page(spec["title"], spec["mode"], body, script)
+
+
+def feedback_text(option: dict[str, str], is_correct: bool) -> str:
+    if option["explanation"]:
+        return option["explanation"]
+    if is_correct:
+        return "這個選項符合此題目前採用的判準。回到 Codex 後可查看完整來源與推理。"
+    return "這個選項未通過此題目前採用的判準。記錄後，系統會安排後續複習。"
+
+
+def render_feedback(spec: dict[str, Any], selected_id: str, csrf_token: str) -> str:
+    option_map = {option["id"]: option for option in spec["options"]}
+    selected = option_map[selected_id]
+    correct = option_map[spec["correct_option_ids"][0]]
+    is_correct = selected_id == correct["id"]
+    if is_correct:
+        band_class, result_label, result_title = (
+            "result-band",
+            "回答正確",
+            "這個判斷站得住腳",
+        )
+        rows = (
+            '<section class="answer-section"><div class="answer-row correct">'
+            '<p class="answer-tag">你的答案・正確</p>'
+            f'<p class="answer-title">{html.escape(correct["label"])}</p>'
+            f'<p class="explanation">{html.escape(feedback_text(correct, True))}</p>'
+            "</div></section>"
+        )
+        action = (
+            '<p class="next"><strong>這一題已完成。</strong><br>'
+            "可以關閉此頁，回到 Codex 進入下一步。</p>"
+        )
+        script = "document.querySelector('#result-title')?.focus();"
+    else:
+        band_class, result_label, result_title = (
+            "result-band error",
+            "需要再校準",
+            "先把這個錯誤留下來",
+        )
+        rows = (
+            '<section class="answer-section"><div class="answer-row wrong">'
+            '<p class="answer-tag">你的答案・錯誤</p>'
+            f'<p class="answer-title">{html.escape(selected["label"])}</p>'
+            f'<p class="explanation">{html.escape(feedback_text(selected, False))}</p></div>'
+            '<div class="answer-row correct"><p class="answer-tag">正確答案</p>'
+            f'<p class="answer-title">{html.escape(correct["label"])}</p>'
+            f'<p class="explanation">{html.escape(feedback_text(correct, True))}</p>'
+            "</div></section>"
+        )
+        action = (
+            '<p class="record-copy">按下「記錄這個錯誤」，系統會把核心命題、情境與誤解加入複習佇列。</p>'
+            '<button class="primary record" id="record" type="button">記錄這個錯誤</button>'
+            '<p class="status" id="status" role="status" aria-live="polite"></p>'
+        )
+        script = """
+document.querySelector('#result-title')?.focus();const token=__TOKEN__;const record=document.querySelector('#record');const status=document.querySelector('#status');
+record.addEventListener('click',async()=>{record.disabled=true;status.textContent='正在加入複習佇列…';try{const response=await fetch('/record',{method:'POST',headers:{'Content-Type':'application/json','X-Choice-Token':token},body:'{}'});if(!response.ok)throw new Error(await response.text());const nextPage=await response.text();document.open();document.write(nextPage);document.close();}catch(error){status.textContent='記錄失敗。請保留此頁，回到 Codex 後再試一次。';record.disabled=false;}});
+""".replace("__TOKEN__", json.dumps(csrf_token))
+    core = ""
+    if spec["core_proposition"]:
+        core = (
+            '<p class="core"><strong>這題在檢查：</strong> '
+            + html.escape(spec["core_proposition"])
+            + "</p>"
+        )
+    body = (
+        f'<main class="sheet"><header class="{band_class}">'
+        f'<p class="result-label">{result_label}</p><h1 id="result-title" tabindex="-1">{result_title}</h1></header>'
+        f"{rows}{core}{action}</main>"
+    )
+    return render_page(result_label, spec["mode"], body, script)
+
+
+def render_selection_recorded(spec: dict[str, Any], selected: dict[str, str]) -> str:
+    body = (
+        '<main class="sheet"><header class="result-band"><p class="result-label">選擇已記錄</p>'
+        '<h1>已收到你的決定</h1></header><section class="answer-section">'
+        '<div class="answer-row correct"><p class="answer-tag">已選擇</p>'
+        f'<p class="answer-title">{html.escape(selected["label"])}</p></div></section>'
+        '<p class="next">可以關閉此頁，回到 Codex 進入下一步。</p></main>'
+    )
+    return render_page("選擇已記錄", spec["mode"], body)
+
+
+def render_review_recorded(spec: dict[str, Any]) -> str:
+    body = (
+        '<main class="sheet"><header class="result-band"><p class="result-label">已加入複習</p>'
+        '<h1>錯誤已記錄</h1></header>'
+        '<p class="prompt">下一次複習會保留同一個核心命題與情境，並改用新的題型、問法與選項重新檢核。</p>'
+        '<p class="next"><strong>記錄完成。</strong><br>可以關閉此頁，回到 Codex 進入下一步。</p></main>'
+    )
+    return render_page("錯誤已記錄", spec["mode"], body)
+
+
+def write_json_once(path: Path, payload: dict[str, Any]) -> None:
+    encoded = (json.dumps(payload, ensure_ascii=False, indent=2) + "\n").encode("utf-8")
+    descriptor = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+    try:
+        with os.fdopen(descriptor, "wb") as handle:
+            handle.write(encoded)
+            handle.flush()
+            os.fsync(handle.fileno())
+    except Exception:
+        path.unlink(missing_ok=True)
+        raise
+
+
+def build_answer(spec: dict[str, Any], selected: dict[str, str]) -> dict[str, Any]:
+    is_correct = (
+        selected["id"] in spec["correct_option_ids"]
+        if spec["kind"] == "knowledge"
+        else None
+    )
+    answered_at = utc_now()
+    feedback_exposed = spec["mode"] in {"learn", "review"}
+    return {
+        "schema_version": 2,
+        "question_id": spec["question_id"],
+        "kind": spec["kind"],
+        "mode": spec["mode"],
+        "concept_id": spec["concept_id"] or None,
+        "knowledge_kernel_id": spec["knowledge_kernel_id"] or None,
+        "scenario_id": spec["scenario_id"] or None,
+        "question_family": spec["question_family"] or None,
+        "review_of": spec["review_of"] or None,
+        "displayed_option_order": [option["id"] for option in spec["options"]],
+        "selected_option_id": selected["id"],
+        "selected_misconception_tag": selected["misconception_tag"] or None,
+        "is_correct": is_correct,
+        "independence": "feedback_exposed" if feedback_exposed else "independent",
+        "feedback_exposed": feedback_exposed,
+        "feedback_available": spec["kind"] == "knowledge",
+        "feedback_timing": (
+            "immediate_after_commit" if spec["kind"] == "knowledge" else "not_scored"
+        ),
+        "requires_review_record": is_correct is False,
+        "answered_at": answered_at,
+    }
+
+
+def build_review_record(
+    spec: dict[str, Any], selected: dict[str, str], correct: dict[str, str]
+) -> dict[str, Any]:
+    correct_position = [item["id"] for item in spec["options"]].index(correct["id"])
+    return {
+        "schema_version": 1,
+        "record_type": "review_seed",
+        "status": "due",
+        "question_id": spec["question_id"],
+        "root_question_id": spec["review_of"] or spec["question_id"],
+        "source_mode": spec["mode"],
+        "concept_id": spec["concept_id"] or None,
+        "knowledge_kernel_id": spec["knowledge_kernel_id"] or None,
+        "scenario_id": spec["scenario_id"] or None,
+        "core_proposition": spec["core_proposition"] or None,
+        "scenario_context": spec["scenario_context"] or None,
+        "source_question_family": spec["question_family"] or None,
+        "source_prompt": spec["prompt"],
+        "source_correct_position": correct_position,
+        "source_options": [
+            {
+                "id": item["id"],
+                "label": item["label"],
+                "description": item["description"],
+                "misconception_tag": item["misconception_tag"] or None,
+            }
+            for item in spec["options"]
+        ],
+        "selected_option": {
+            "id": selected["id"],
+            "label": selected["label"],
+            "explanation": feedback_text(selected, False),
+            "misconception_tag": selected["misconception_tag"] or None,
+        },
+        "correct_option": {
+            "id": correct["id"],
+            "label": correct["label"],
+            "explanation": feedback_text(correct, True),
+        },
+        "review_contract": {
+            "preserve": [
+                "knowledge_kernel_id",
+                "core_proposition",
+                "scenario_id",
+                "scenario_context",
+            ],
+            "change": [
+                "question_family",
+                "prompt",
+                "option_ids",
+                "option_wording",
+                "distractors",
+                "correct_option_position",
+            ],
+        },
+        "recorded_at": utc_now(),
+    }
+
+
+def make_handler(
+    spec: dict[str, Any], answer_path: Path, review_record_path: Path, csrf_token: str
+) -> type[BaseHTTPRequestHandler]:
+    option_map = {option["id"]: option for option in spec["options"]}
+    browser_options = {secrets.token_urlsafe(18): option for option in spec["options"]}
+    question_html = render_question(spec, csrf_token, browser_options).encode("utf-8")
+
+    class ChoiceHandler(BaseHTTPRequestHandler):
+        server_version = "MasteryChoice/2.0"
+
+        def log_message(self, format_string: str, *args: object) -> None:
+            return
+
+        def send_payload(
+            self, status: int, payload: bytes, content_type: str = "text/html; charset=utf-8"
+        ) -> None:
+            self.send_response(status)
+            self.send_header("Content-Type", content_type)
+            self.send_header("Content-Length", str(len(payload)))
+            self.send_header("Cache-Control", "no-store")
+            self.send_header("X-Content-Type-Options", "nosniff")
+            self.send_header("X-Frame-Options", "DENY")
+            self.send_header("Referrer-Policy", "no-referrer")
+            self.send_header(
+                "Content-Security-Policy",
+                "default-src 'none'; style-src 'unsafe-inline'; script-src 'unsafe-inline'; connect-src 'self'; frame-ancestors 'none'; base-uri 'none'; form-action 'self'",
+            )
+            self.end_headers()
+            self.wfile.write(payload)
+
+        def current_answer(self) -> dict[str, Any] | None:
+            if not answer_path.exists():
+                return None
+            try:
+                return read_json(answer_path)
+            except (OSError, json.JSONDecodeError, SpecError):
+                return None
+
+        def do_GET(self) -> None:
+            if self.path == "/":
+                answer = self.current_answer()
+                if answer and answer.get("selected_option_id") in option_map:
+                    if answer.get("is_correct") is False and review_record_path.exists():
+                        page = render_review_recorded(spec)
+                    elif spec["kind"] == "knowledge":
+                        page = render_feedback(spec, answer["selected_option_id"], csrf_token)
+                    else:
+                        page = render_selection_recorded(
+                            spec, option_map[answer["selected_option_id"]]
+                        )
+                    self.send_payload(200, page.encode("utf-8"))
+                    return
+                self.send_payload(200, question_html)
+                return
+            if self.path == "/health":
+                self.send_payload(200, b'{"ok":true}', "application/json")
+                return
+            self.send_payload(404, b"Not found", "text/plain; charset=utf-8")
+
+        def parse_post(self) -> dict[str, Any] | None:
+            if self.headers.get("X-Choice-Token") != csrf_token:
+                self.send_payload(403, b"Invalid choice token", "text/plain; charset=utf-8")
+                return None
+            try:
+                length = int(self.headers.get("Content-Length", "0"))
+            except ValueError:
+                length = 0
+            if length < 2 or length > 4096:
+                self.send_payload(400, b"Invalid request size", "text/plain; charset=utf-8")
+                return None
+            try:
+                body = json.loads(self.rfile.read(length).decode("utf-8"))
+            except (UnicodeDecodeError, json.JSONDecodeError):
+                self.send_payload(400, b"Invalid JSON", "text/plain; charset=utf-8")
+                return None
+            if not isinstance(body, dict):
+                self.send_payload(400, b"Invalid JSON object", "text/plain; charset=utf-8")
+                return None
+            return body
+
+        def do_POST(self) -> None:
+            if self.path == "/answer":
+                self.handle_answer()
+            elif self.path == "/record":
+                self.handle_record()
+            else:
+                self.send_payload(404, b"Not found", "text/plain; charset=utf-8")
+
+        def handle_answer(self) -> None:
+            body = self.parse_post()
+            if body is None:
+                return
+            selected = browser_options.get(body.get("option_token"))
+            if selected is None:
+                self.send_payload(400, b"Unknown option", "text/plain; charset=utf-8")
+                return
+            try:
+                write_json_once(answer_path, build_answer(spec, selected))
+            except FileExistsError:
+                self.send_payload(409, b"Answer already exists", "text/plain; charset=utf-8")
+                return
+            if spec["kind"] == "knowledge":
+                page = render_feedback(spec, selected["id"], csrf_token)
+                waits_for_record = selected["id"] not in spec["correct_option_ids"]
+            else:
+                page = render_selection_recorded(spec, selected)
+                waits_for_record = False
+            self.send_payload(200, page.encode("utf-8"))
+            if not waits_for_record:
+                threading.Thread(target=self.server.shutdown, daemon=True).start()
+
+        def handle_record(self) -> None:
+            body = self.parse_post()
+            if body is None:
+                return
+            if body:
+                self.send_payload(400, b"Record body must be empty", "text/plain; charset=utf-8")
+                return
+            answer = self.current_answer()
+            if not answer or answer.get("is_correct") is not False:
+                self.send_payload(409, b"No wrong answer to record", "text/plain; charset=utf-8")
+                return
+            selected_id = answer.get("selected_option_id")
+            if selected_id not in option_map or not spec["correct_option_ids"]:
+                self.send_payload(409, b"Answer state is incomplete", "text/plain; charset=utf-8")
+                return
+            selected = option_map[selected_id]
+            correct = option_map[spec["correct_option_ids"][0]]
+            try:
+                write_json_once(
+                    review_record_path, build_review_record(spec, selected, correct)
+                )
+            except FileExistsError:
+                pass
+            self.send_payload(200, render_review_recorded(spec).encode("utf-8"))
+            threading.Thread(target=self.server.shutdown, daemon=True).start()
+
+    return ChoiceHandler
+
+
+def command_validate(workspace: Path, spec_arg: str) -> int:
+    spec_path, spec = load_spec(workspace, spec_arg)
+    print(
+        json.dumps(
+            {
+                "valid": True,
+                "schema_version": spec["schema_version"],
+                "spec": str(spec_path),
+                "question_id": spec["question_id"],
+                "kind": spec["kind"],
+                "mode": spec["mode"],
+                "options": len(spec["options"]),
+                "correct_options": len(spec["correct_option_ids"]),
+                "immediate_feedback": spec["kind"] == "knowledge",
+                "review_of": spec["review_of"] or None,
+            },
+            ensure_ascii=False,
+        )
+    )
+    return 0
+
+
+def command_serve(workspace: Path, spec_arg: str, port: int, idle_timeout: int) -> int:
+    _, spec = load_spec(workspace, spec_arg)
+    answer_path = answer_path_for(workspace, spec["question_id"])
+    review_path = review_record_path_for(workspace, spec["question_id"])
+    status = "ready"
+    if answer_path.exists():
+        answer = read_json(answer_path)
+        pending_record = answer.get("is_correct") is False and not review_path.exists()
+        if not pending_record:
+            raise SpecError(f"Question is already complete; use a new question_id: {answer_path}")
+        status = "resume_record"
+    csrf_token = secrets.token_urlsafe(32)
+    server = ThreadingHTTPServer(
+        ("127.0.0.1", port), make_handler(spec, answer_path, review_path, csrf_token)
+    )
+    url = f"http://127.0.0.1:{server.server_address[1]}/"
+    print(
+        json.dumps(
+            {
+                "status": status,
+                "url": url,
+                "question_id": spec["question_id"],
+                "answer_path": str(answer_path),
+                "review_record_path": str(review_path),
+                "idle_timeout_seconds": idle_timeout,
+            },
+            ensure_ascii=False,
+        ),
+        flush=True,
+    )
+    timer = None
+    if idle_timeout > 0:
+        timer = threading.Timer(idle_timeout, server.shutdown)
+        timer.daemon = True
+        timer.start()
+    try:
+        server.serve_forever(poll_interval=0.1)
+    except KeyboardInterrupt:
+        pass
+    finally:
+        if timer is not None:
+            timer.cancel()
+        server.server_close()
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Mastery Loop local click-choice UI")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    for name in ("validate", "serve"):
+        sub = subparsers.add_parser(name)
+        sub.add_argument("--workspace", required=True, help="Learning workspace root")
+        sub.add_argument("--spec", required=True, help="Spec JSON inside the workspace")
+        if name == "serve":
+            sub.add_argument("--port", type=int, default=0, help="Loopback port")
+            sub.add_argument(
+                "--idle-timeout",
+                type=int,
+                default=900,
+                help="Seconds before an abandoned page shuts down; 0 disables",
+            )
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    workspace = Path(args.workspace).expanduser().resolve()
+    if not workspace.is_dir():
+        raise SpecError(f"Workspace directory not found: {workspace}")
+    if args.command == "validate":
+        return command_validate(workspace, args.spec)
+    if args.idle_timeout < 0:
+        raise SpecError("idle-timeout must be 0 or greater")
+    return command_serve(workspace, args.spec, args.port, args.idle_timeout)
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except SpecError as exc:
+        print(json.dumps({"error": str(exc)}, ensure_ascii=False))
+        raise SystemExit(2)

--- a/weeks/2026/2026-w35-mastery-loop/completed/mastery-loop/scripts/init_workspace.py
+++ b/weeks/2026/2026-w35-mastery-loop/completed/mastery-loop/scripts/init_workspace.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python3
+"""Initialize a Mastery Loop workspace without overwriting files."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+
+MISSION_TEMPLATE = """# Mission: {topic}
+
+Goal intent: unselected
+
+## Why
+{why}
+
+## Success looks like
+- To define with learner: an observable real-world performance.
+
+## Constraints
+- To define with learner: time, tools, deadline, accessibility, or risk.
+
+## Out of scope
+- To define with learner: adjacent topics to defer.
+"""
+
+KNOWLEDGE_MAP_TEMPLATE = """# Knowledge Map: {topic}
+
+Benchmark status: provisional
+Last verified: NOT VERIFIED
+
+| Concept / performance | Kernel ID | Scenario ID | Required | Prerequisites | Failure signal | Source |
+|---|---|---|---:|---|---|---|
+| To define with learner | TODO | TODO | T | To define | To define | NOT VERIFIED |
+
+## Open benchmark gaps
+- Define mission-critical concepts and verify them against authoritative sources.
+"""
+
+MASTERY_TEMPLATE = """# Mastery State: {topic}
+
+Mode: {mode}
+Session status: active
+Cycle position: {cycle_position}
+Last updated: NOT ASSESSED
+Overall claim: not assessed
+Claim scope: {why}
+
+| Concept / performance | Required | Current | Confidence | Strongest evidence | Counterevidence | Next probe | Due |
+|---|---:|---:|---:|---|---|---|---|
+| TODO | T | U | Low | None | Unassessed | Establish an uncued Audit baseline | Next session |
+
+## Active misconceptions
+- None recorded.
+
+## Session queue
+1. Establish an uncued baseline for the highest-priority concept.
+"""
+
+RESOURCES_TEMPLATE = """# {topic} Resources
+
+## Knowledge
+- To research: an authoritative source annotated with what it supports.
+
+## Practice
+- To evaluate: a high-signal practice venue, coach, reviewer, or community.
+
+## Gaps
+- The mission benchmark has not yet been verified.
+"""
+
+NOTES_TEMPLATE = """# Learning Notes
+
+## Preferences
+- Language: match the learner.
+- Interaction: mouse-first clickable choices.
+- Feedback: immediate explanation after commitment.
+- Evidence: v3 answers and learning events save automatically after commitment.
+- Session time box: To capture
+- Accommodations: To capture
+"""
+
+
+def write_new(path: Path, content: str) -> str:
+    if path.exists():
+        return f"SKIP {path.name}: already exists"
+    path.write_text(content, encoding="utf-8")
+    return f"CREATE {path.name}"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Initialize a Mastery Loop workspace without overwriting state."
+    )
+    parser.add_argument("--path", required=True, help="Workspace directory")
+    parser.add_argument("--topic", required=True, help="Learning topic")
+    parser.add_argument("--why", required=True, help="Observable real-world goal")
+    parser.add_argument(
+        "--mode", choices=("audit", "learn", "review"), default="audit"
+    )
+    args = parser.parse_args()
+
+    root = Path(args.path).expanduser().resolve()
+    root.mkdir(parents=True, exist_ok=True)
+    for dirname in (
+        "mastery-sessions",
+        "choice-sessions",
+        "review-records",
+        "assessment-records",
+        "learning-records",
+        "lessons",
+        "reference",
+        "assets",
+    ):
+        (root / dirname).mkdir(exist_ok=True)
+
+    cycle_position = {
+        "audit": "Audit",
+        "learn": "Learn",
+        "review": "Review",
+    }[args.mode]
+    outputs = [
+        write_new(
+            root / "MISSION.md",
+            MISSION_TEMPLATE.format(topic=args.topic, why=args.why),
+        ),
+        write_new(
+            root / "KNOWLEDGE-MAP.md", KNOWLEDGE_MAP_TEMPLATE.format(topic=args.topic)
+        ),
+        write_new(
+            root / "MASTERY.md",
+            MASTERY_TEMPLATE.format(
+                topic=args.topic,
+                mode=args.mode,
+                cycle_position=cycle_position,
+                why=args.why,
+            ),
+        ),
+        write_new(root / "RESOURCES.md", RESOURCES_TEMPLATE.format(topic=args.topic)),
+        write_new(root / "NOTES.md", NOTES_TEMPLATE),
+    ]
+
+    print(f"Workspace: {root}")
+    for output in outputs:
+        print(output)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/weeks/2026/2026-w35-mastery-loop/completed/mastery-loop/scripts/mastery_session_ui.py
+++ b/weeks/2026/2026-w35-mastery-loop/completed/mastery-loop/scripts/mastery_session_ui.py
@@ -1,0 +1,1745 @@
+#!/usr/bin/env python3
+"""Serve Mastery Loop v3 phases in one local browser tab per phase.
+
+The browser receives only the current visible surface. Stable identifiers,
+correct answers, explanations, future questions, and score calculations stay
+on the loopback server until the learner commits an answer.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hmac
+import html
+import json
+import re
+import secrets
+import sys
+import threading
+from dataclasses import dataclass
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from typing import Any, Callable, Mapping
+
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
+
+import session_core as core
+
+
+MAX_BODY_BYTES = 64 * 1024
+PHASE_LABELS = {"assessment": "評估", "learning": "學習", "review": "複習"}
+BENCHMARK_LABELS = {
+    "verified": "已驗證",
+    "partially_verified": "部分驗證",
+    "provisional": "暫定",
+}
+DIFFICULTY_LABELS = {
+    "foundation": "基礎",
+    "core": "核心",
+    "advanced": "進階",
+}
+REQUEST_ID_RE = re.compile(r"^[a-z0-9][a-z0-9._-]{0,127}$")
+CHOICE_KEYBOARD_JS = """choices.forEach((choice,index)=>{choice.addEventListener('change',()=>button.disabled=false);choice.addEventListener('keydown',event=>{let target=index;if(event.key==='ArrowDown'||event.key==='ArrowRight')target=(index+1)%choices.length;else if(event.key==='ArrowUp'||event.key==='ArrowLeft')target=(index+choices.length-1)%choices.length;else if(event.key!==' '&&event.key!=='Enter')return;event.preventDefault();const next=choices[target];next.checked=true;next.focus();next.dispatchEvent(new Event('change',{bubbles:true}));});});"""
+
+
+class UiError(RuntimeError):
+    """Raised when a browser action violates the current UI state."""
+
+
+@dataclass(frozen=True)
+class SessionBundle:
+    workspace: Path
+    cycle_dir: Path
+    cycle: dict[str, Any]
+    phase: str
+    phase_dir: Path
+    spec: dict[str, Any]
+    slices: dict[str, dict[str, Any]] | None = None
+    assessment_spec: dict[str, Any] | None = None
+    assessment_report: dict[str, Any] | None = None
+    learning_report: dict[str, Any] | None = None
+
+
+def _artifact_path(
+    cycle_dir: Path,
+    cycle: Mapping[str, Any],
+    key: str,
+    default: str,
+    *,
+    required: bool = True,
+) -> Path:
+    value = cycle.get("artifacts", {}).get(key, default)
+    candidate = Path(value)
+    if not candidate.is_absolute():
+        candidate = cycle_dir / candidate
+    path = core.resolve_within(cycle_dir, candidate)
+    if required and not path.is_file():
+        raise core.SpecError(f"Required artifact not found: {path}")
+    return path
+
+
+def _read_optional(path: Path) -> dict[str, Any] | None:
+    return core.read_json_object(path) if path.is_file() else None
+
+
+def _load_slice_files(cycle_dir: Path, path_spec: Mapping[str, Any]) -> dict[str, dict[str, Any]]:
+    slices_dir = core.resolve_within(cycle_dir, cycle_dir / "learning" / "slices")
+    result: dict[str, dict[str, Any]] = {}
+    for area in path_spec.get("areas", []):
+        for slice_id in area.get("slice_ids", []):
+            path = core.resolve_within(slices_dir, slices_dir / f"{slice_id}.json")
+            if not path.is_file():
+                raise core.SpecError(f"Learning slice not found: {path}")
+            result[slice_id] = core.read_json_object(path)
+    return result
+
+
+def load_phase_bundle(workspace: Path, cycle_ref: str, phase: str) -> SessionBundle:
+    raw_workspace = Path(workspace).expanduser()
+    workspace = core.resolve_within(raw_workspace, raw_workspace)
+    cycle_dir, cycle = core.load_cycle(workspace, cycle_ref)
+    if phase == "assessment":
+        spec_path = _artifact_path(cycle_dir, cycle, "assessment_spec", "assessment/spec.json")
+        spec = core.validate_assessment_spec(core.read_json_object(spec_path), cycle)
+        core.validate_batch_manifest(spec_path.parent, spec)
+        return SessionBundle(workspace, cycle_dir, cycle, phase, spec_path.parent, spec)
+    if phase == "learning":
+        assessment_spec_file = _artifact_path(
+            cycle_dir, cycle, "assessment_spec", "assessment/spec.json"
+        )
+        assessment_spec = core.validate_assessment_spec(
+            core.read_json_object(assessment_spec_file), cycle
+        )
+        assessment_report = core.build_assessment_report(
+            assessment_spec_file.parent,
+            assessment_spec,
+            require_complete=True,
+        )
+        path_file = _artifact_path(cycle_dir, cycle, "learning_path", "learning/path.json")
+        raw_path = core.read_json_object(path_file)
+        slices = _load_slice_files(cycle_dir, raw_path)
+        spec = core.validate_learning_path(
+            raw_path,
+            cycle,
+            slices=slices,
+            assessment_report=assessment_report,
+            assessment_spec=assessment_spec,
+        )
+        normalized_slices = {
+            item_id: core.validate_learning_slice(item, {area["area_id"] for area in cycle["areas"]})
+            for item_id, item in slices.items()
+        }
+        return SessionBundle(
+            workspace,
+            cycle_dir,
+            cycle,
+            phase,
+            path_file.parent,
+            spec,
+            normalized_slices,
+            assessment_report=assessment_report,
+        )
+    if phase == "review":
+        review_file = _artifact_path(cycle_dir, cycle, "review_spec", "review/spec.json")
+        assessment_file = _artifact_path(
+            cycle_dir, cycle, "assessment_spec", "assessment/spec.json"
+        )
+        learning_path_file = _artifact_path(
+            cycle_dir, cycle, "learning_path", "learning/path.json"
+        )
+        assessment_spec = core.validate_assessment_spec(
+            core.read_json_object(assessment_file), cycle
+        )
+        assessment_report = core.build_assessment_report(
+            assessment_file.parent,
+            assessment_spec,
+            require_complete=True,
+        )
+        learning_raw = core.read_json_object(learning_path_file)
+        slices = _load_slice_files(cycle_dir, learning_raw)
+        learning_spec = core.validate_learning_path(
+            learning_raw,
+            cycle,
+            slices=slices,
+            assessment_report=assessment_report,
+            assessment_spec=assessment_spec,
+        )
+        normalized_slices = {
+            item_id: core.validate_learning_slice(
+                item, {area["area_id"] for area in cycle["areas"]}
+            )
+            for item_id, item in slices.items()
+        }
+        learning_report = core.build_learning_report(
+            learning_path_file.parent,
+            learning_spec,
+            slices=normalized_slices,
+            require_complete=True,
+        )
+        spec = core.validate_review_spec(
+            core.read_json_object(review_file),
+            cycle,
+            assessment_spec=assessment_spec,
+            learning_path=learning_spec,
+            learning_slices=normalized_slices,
+            assessment_report=assessment_report,
+            learning_report=learning_report,
+        )
+        core.validate_batch_manifest(review_file.parent, spec)
+        return SessionBundle(
+            workspace,
+            cycle_dir,
+            cycle,
+            phase,
+            review_file.parent,
+            spec,
+            normalized_slices,
+            assessment_spec,
+            assessment_report,
+            learning_report,
+        )
+    raise core.SpecError(f"Unsupported phase: {phase}")
+
+
+STYLE = """
+:root{color-scheme:light;--canvas:#f4f0e7;--paper:#fffdf8;--ink:#202126;--muted:#696870;--rule:#d9d4c9;--purple:#6552d9;--purple-dark:#4c3db1;--lime:#dff28f;--green:#287a50;--green-bg:#edf8f0;--red:#a23b42;--red-bg:#fff0f0;--blue:#1769e0;--shadow:0 18px 55px rgba(42,37,29,.09)}
+*{box-sizing:border-box}body{margin:0;background:var(--canvas);color:var(--ink);font-family:Aptos,"Noto Sans TC","Microsoft JhengHei",system-ui,sans-serif;line-height:1.65}
+.shell{width:min(100% - 32px,960px);margin:28px auto}.topline{display:flex;align-items:center;justify-content:space-between;gap:16px;margin-bottom:12px;color:var(--muted);font-size:.92rem}.brand{font-weight:750;color:var(--ink);letter-spacing:.02em}.phase{padding:4px 9px;border:1px solid var(--rule);border-radius:999px;background:rgba(255,255,255,.5)}
+main{background:var(--paper);border-radius:12px;box-shadow:var(--shadow);padding:clamp(24px,5vw,52px);overflow-wrap:anywhere}h1,h2,h3{line-height:1.25;margin:0 0 16px}h1{font-size:clamp(1.7rem,5vw,2.7rem);letter-spacing:-.035em}h2{font-size:1.25rem}p{max-width:75ch}.lede{font-size:1.08rem;color:#45454c;margin-bottom:26px}.eyebrow{font-size:.78rem;font-weight:800;letter-spacing:.11em;text-transform:uppercase;color:var(--purple);margin:0 0 9px}
+.grid{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:14px}.scope-grid{margin-top:14px}.card{border:1px solid var(--rule);border-radius:8px;padding:17px;background:#fff}.card h3{font-size:1rem;margin-bottom:7px}.card p{margin:0;color:var(--muted)}.scope-list{margin:8px 0 0;padding-left:20px}.scope-list li+li{margin-top:5px}.meta{display:flex;gap:10px;flex-wrap:wrap;margin:18px 0}.chip{display:inline-flex;align-items:center;min-height:32px;padding:4px 10px;border-radius:999px;background:#efecfa;color:#41348e;font-size:.88rem;font-weight:650}
+.button{appearance:none;border:0;border-radius:4px;min-height:46px;padding:11px 20px;background:var(--purple);color:white;font:inherit;font-weight:750;cursor:pointer;display:inline-flex;align-items:center;justify-content:center;text-decoration:none}.button:hover{background:var(--purple-dark)}.button:disabled{opacity:.52;cursor:not-allowed}.button.secondary{background:#ece9e1;color:var(--ink)}button:focus-visible,a:focus-visible,input:focus-visible{outline:3px solid var(--blue);outline-offset:3px}.actions{margin-top:28px;display:flex;justify-content:flex-end;gap:10px;flex-wrap:wrap}
+.progress-row{display:flex;align-items:flex-end;justify-content:space-between;gap:16px;margin-bottom:9px}.progress-copy strong{display:block;font-size:1.05rem}.progress-copy span{color:var(--muted);font-size:.9rem}progress{display:block;width:100%;height:9px;border:0;border-radius:99px;overflow:hidden;background:#e5e0d6;margin-bottom:30px}progress::-webkit-progress-bar{background:#e5e0d6}progress::-webkit-progress-value{background:var(--purple)}progress::-moz-progress-bar{background:var(--purple)}
+.scenario{border:1px solid #d8d1ee;border-radius:7px;padding:14px 16px;background:#f7f5fd;color:#4d4c52;margin:20px 0}.prompt{font-size:1.16rem;font-weight:720;max-width:70ch}.choice-fieldset{border:0;padding:0;margin:0}.choices{display:grid;gap:11px;margin-top:22px}.choice{position:relative}.choice input{position:absolute;opacity:0;pointer-events:none}.choice label{display:block;min-height:58px;padding:14px 16px;border:1px solid var(--rule);border-radius:7px;background:white;cursor:pointer;transition:border-color .15s,background .15s}.choice label:hover{border-color:#aaa1d7}.choice input:checked+label{border-color:var(--purple);background:#f5f2ff}.choice input:focus-visible+label{outline:3px solid var(--blue);outline-offset:3px}.choice-title{display:block;font-weight:730}.choice-desc{display:block;color:var(--muted);font-size:.94rem;margin-top:2px}.status{min-height:1.6em;color:var(--red);margin-top:10px}
+.result{border-radius:8px;padding:20px;margin:20px 0}.result.correct{background:var(--green-bg);border:1px solid #b9dfc5}.result.wrong{background:var(--red-bg);border:1px solid #efc5c7}.result h2{display:flex;gap:9px;align-items:center}.answer-grid{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:14px;margin:18px 0}.answer{border:1px solid var(--rule);padding:16px;border-radius:8px}.answer strong{display:block;margin-bottom:5px}.answer p{margin:0}.explanation{margin-top:9px;color:#48474d}.live{min-height:1px}
+.summary{display:grid;grid-template-columns:repeat(3,minmax(0,1fr));gap:12px;margin:22px 0}.metric{background:var(--lime);padding:16px;border-radius:8px}.metric strong{display:block;font-size:1.55rem;line-height:1.2}.metric span{font-size:.88rem}.table-wrap{overflow-x:auto;border:1px solid var(--rule);border-radius:8px}table{width:100%;border-collapse:collapse;min-width:720px}th,td{text-align:left;vertical-align:top;padding:13px;border-bottom:1px solid var(--rule)}th{background:#f3f0e9;font-size:.86rem}tr:last-child td{border-bottom:0}.signal{font-weight:750}.signal.stable_signal{color:var(--green)}.signal.needs_support{color:var(--red)}.fine{color:var(--muted);font-size:.9rem}.notice{border:1px solid var(--rule);border-radius:8px;padding:16px;margin-top:20px;background:#faf8f2}
+.map{display:grid;gap:14px;margin:22px 0}.map-area{border:1px solid var(--rule);border-radius:8px;padding:16px;background:#fff}.map-area h3{margin-bottom:10px}.nodes{display:flex;gap:8px;flex-wrap:wrap}.node{display:inline-flex;align-items:center;min-height:44px;padding:8px 11px;border:1px solid var(--rule);border-radius:6px;color:var(--ink);text-decoration:none;background:#faf9f5;font-size:.9rem}.node.done{border-color:#9acbad;background:var(--green-bg)}.node.current{border-color:var(--purple);background:#f5f2ff;font-weight:750}.node.locked{color:#69676d;background:#f0eee8}.node.checkpoint{border-style:dashed}.lesson-section{padding:19px 0;border-top:1px solid var(--rule)}.lesson-section:first-of-type{border-top:0}.lesson-section h2{font-size:1.12rem}.callout{padding:16px;border:1px solid #d8d1ee;border-radius:7px;background:#f7f5fd}.takeaways{background:var(--lime);border-radius:8px;padding:18px}.source-list{word-break:break-word}.back{display:inline-flex;align-items:center;min-height:44px;color:var(--purple);font-weight:700}.lock-note{color:var(--muted);font-size:.88rem;margin-top:10px}
+footer{text-align:center;color:var(--muted);font-size:.84rem;padding:22px 8px 8px}@media(max-width:700px){.shell{width:min(100% - 20px,960px);margin:10px auto}.grid,.answer-grid,.summary{grid-template-columns:1fr}main{padding:22px 18px}.topline{padding:0 4px}.actions .button{width:100%}.progress-row{align-items:flex-start;flex-direction:column;gap:3px}}
+@media(prefers-reduced-motion:reduce){*,*::before,*::after{scroll-behavior:auto!important;transition:none!important;animation:none!important}}
+"""
+
+
+def _esc(value: Any) -> str:
+    return html.escape(str(value), quote=True)
+
+
+def _json_script(value: Any) -> str:
+    return json.dumps(value, ensure_ascii=False).replace("<", "\\u003c")
+
+
+def _same_token(provided: Any, expected: str) -> bool:
+    return isinstance(provided, str) and hmac.compare_digest(provided, expected)
+
+
+def render_page(title: str, phase: str, body: str, script: str, nonce: str) -> str:
+    script_tag = f'<script nonce="{_esc(nonce)}">{script}</script>' if script else ""
+    return f"""<!doctype html>
+<html lang="zh-Hant"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><title>{_esc(title)}</title><style nonce="{_esc(nonce)}">{STYLE}</style></head>
+<body><div class="shell"><div class="topline"><span class="brand">Mastery Loop</span><span class="phase">{_esc(PHASE_LABELS[phase])}</span></div><main>{body}</main><footer>Created by Winston</footer></div>{script_tag}</body></html>"""
+
+
+def _button_script(endpoint: str, csrf: str, payload: Mapping[str, Any], button_id: str) -> str:
+    return f"""(()=>{{const button=document.getElementById({_json_script(button_id)});const status=document.getElementById('status');if(!button)return;button.addEventListener('click',async()=>{{button.disabled=true;status.textContent='';try{{const response=await fetch({_json_script(endpoint)},{{method:'POST',headers:{{'Content-Type':'application/json','X-Mastery-Token':{_json_script(csrf)}}},body:JSON.stringify({_json_script(payload)})}});const page=await response.text();if(!response.ok)throw new Error(page);document.open();document.write(page);document.close();}}catch(error){{status.textContent='操作失敗，請稍後重試。';button.disabled=false;}}}});}})();"""
+
+
+def _assessment_intro_script(csrf: str) -> str:
+    actions = [
+        ("primary", "/start", {"request_id": secrets.token_hex(12)}),
+        (
+            "adjust-scope",
+            "/scope-action",
+            {"request_id": secrets.token_hex(12), "action": "adjust_scope"},
+        ),
+        (
+            "pause-cycle",
+            "/scope-action",
+            {"request_id": secrets.token_hex(12), "action": "pause"},
+        ),
+    ]
+    return "".join(
+        _button_script(endpoint, csrf, payload, button_id)
+        for button_id, endpoint, payload in actions
+    )
+
+
+def _scope_cards(cycle: Mapping[str, Any]) -> str:
+    scope = cycle["knowledge_scope"]
+    areas = "".join(
+        f'<article class="card"><h3>{_esc(area["title"])}</h3><p>{_esc(area["description"])}</p></article>'
+        for area in cycle["areas"]
+    )
+    includes = "".join(f"<li>{_esc(item)}</li>" for item in scope["includes"])
+    excludes = "".join(f"<li>{_esc(item)}</li>" for item in scope["excludes"])
+    sources = "".join(f"<li>{_esc(item)}</li>" for item in scope["sources"])
+    source_block = sources or "<li>目前沒有可列出的來源；基準維持暫定。</li>"
+    return f"""
+<h2>知識範圍</h2><p>{_esc(scope['direction'])}</p>
+<div class="grid">{areas}</div>
+<div class="grid scope-grid"><section class="card"><h3>涵蓋內容</h3><ul class="scope-list">{includes}</ul></section><section class="card"><h3>本輪排除</h3><ul class="scope-list">{excludes or '<li>未列出額外排除項目。</li>'}</ul></section></div>
+<section class="notice"><strong>Benchmark：{_esc(BENCHMARK_LABELS[scope['benchmark_status']])}</strong><ul class="scope-list">{source_block}</ul></section>"""
+
+
+def _cycle_visible_choice_context(
+    cycle: Mapping[str, Any],
+) -> list[tuple[str, str]]:
+    scope = cycle["knowledge_scope"]
+    entries = [
+        ("cycle.mission.ultimate_outcome", cycle["mission"]["ultimate_outcome"]),
+        ("cycle.mission.audience", cycle["mission"]["audience"]),
+        ("cycle.knowledge_scope.title", scope["title"]),
+        ("cycle.knowledge_scope.direction", scope["direction"]),
+    ]
+    for field in ("includes", "excludes", "sources"):
+        entries.extend(
+            (f"cycle.knowledge_scope.{field}[{index}]", value)
+            for index, value in enumerate(scope[field])
+        )
+    for index, area in enumerate(cycle["areas"]):
+        entries.extend(
+            (
+                (f"cycle.areas[{index}].title", area["title"]),
+                (f"cycle.areas[{index}].description", area["description"]),
+            )
+        )
+    return entries
+
+
+def _learning_visible_choice_context(
+    bundle: SessionBundle,
+) -> list[tuple[str, str]]:
+    entries = [("learning.title", bundle.spec["title"])]
+    entries.extend(
+        (f"learning.areas[{index}].title", area["title"])
+        for index, area in enumerate(bundle.spec["areas"])
+    )
+    for slice_id, item in (bundle.slices or {}).items():
+        entries.append((f"learning.slices[{slice_id}].title", item["title"]))
+    return entries
+
+
+def render_assessment_intro(bundle: SessionBundle, csrf: str, nonce: str) -> str:
+    spec = bundle.spec
+    core.validate_visible_context_contract(
+        spec,
+        _cycle_visible_choice_context(bundle.cycle),
+        allow_plain_option_labels=True,
+    )
+    distribution = "".join(
+        f'<span class="chip">{_esc(area["title"])} · {sum(1 for question in spec["questions"] if question["area_id"] == area["area_id"])} 題</span>'
+        for area in bundle.cycle["areas"]
+    )
+    body = f"""
+<p class="eyebrow">開始前確認</p><h1>{_esc(spec['title'])}</h1>
+<p class="lede">目標：{_esc(bundle.cycle['mission']['ultimate_outcome'])}</p>
+{_scope_cards(bundle.cycle)}
+<div class="meta"><span class="chip">{len(spec['questions'])} 題</span><span class="chip">約 {spec['estimated_minutes']} 分鐘</span><span class="chip">{len(bundle.cycle['areas'])} 個主要領域</span></div>
+<section class="notice"><strong>題數分布</strong><div class="meta">{distribution}</div></section>
+<p>{_esc(spec['instructions'])}</p>
+<div class="actions"><button class="button secondary" id="pause-cycle" type="button">暫停</button><button class="button secondary" id="adjust-scope" type="button">調整範圍</button><button class="button" id="primary" type="button">確認範圍並開始</button></div><p id="status" class="status" role="status" aria-live="polite"></p>"""
+    script = _assessment_intro_script(csrf)
+    return render_page(spec["title"], "assessment", body, script, nonce)
+
+
+def render_scope_exit(bundle: SessionBundle, action: str, nonce: str) -> str:
+    if action == "adjust_scope":
+        title = "返回 Codex 調整範圍"
+        copy = "目前尚未開始評估，也沒有建立作答證據。請關閉此頁並回到 Codex 修改學習目標、涵蓋內容或排除內容。"
+    else:
+        title = "本輪已暫停"
+        copy = "目前進度保留在評估開始前。需要繼續時，重新啟動同一個 Assessment phase 即可。"
+    body = f"""<p class="eyebrow">開始前確認</p><h1>{_esc(title)}</h1><section class="notice"><p>{_esc(copy)}</p></section><section class="notice"><strong>下一步</strong><p>請關閉此頁並回到 Codex。</p></section>"""
+    return render_page(title, "assessment", body, "", nonce)
+
+
+def render_review_intro(bundle: SessionBundle, csrf: str, nonce: str) -> str:
+    spec = bundle.spec
+    core.validate_visible_context_contract(
+        spec,
+        _cycle_visible_choice_context(bundle.cycle),
+        allow_plain_option_labels=True,
+    )
+    prior_gaps = len((bundle.assessment_report or {}).get("gaps", [])) + len(
+        (bundle.learning_report or {}).get("gaps", [])
+    )
+    body = f"""
+<p class="eyebrow">整合複習</p><h1>{_esc(spec['title'])}</h1>
+<p class="lede">每題保留核心命題，並改用全新情境、題型、提示與選項，檢查你能否轉用剛完成的知識。</p>
+{_scope_cards(bundle.cycle)}
+<div class="meta"><span class="chip">{len(spec['questions'])} 題</span><span class="chip">{prior_gaps} 個先前缺口訊號</span><span class="chip">包含跨領域整合</span></div>
+<p>{_esc(spec['instructions'])}</p>
+<div class="actions"><button class="button" id="primary" type="button">開始複習</button></div><p id="status" class="status" role="status" aria-live="polite"></p>"""
+    script = _button_script("/start", csrf, {"request_id": secrets.token_hex(12)}, "primary")
+    return render_page(spec["title"], "review", body, script, nonce)
+
+
+def _progress(index: int, total: int, *, feedback: bool = False, noun: str = "題") -> str:
+    completed = index + (1 if feedback else 0)
+    remaining = total - completed
+    return f"""<div class="progress-row"><div class="progress-copy"><strong>第 {index + 1} / {total} {noun}</strong><span>已完成 {completed} {noun} · 剩餘 {remaining} {noun}</span></div></div><progress value="{completed}" max="{total}" aria-label="進度">{completed}/{total}</progress>"""
+
+
+def _render_choice_options(
+    option_tokens: list[tuple[str, Mapping[str, Any]]],
+    *,
+    descriptions_allowed: bool = True,
+) -> str:
+    """Render balanced choices without leaking correctness from legacy copy."""
+
+    show_descriptions = descriptions_allowed and all(
+        core.choice_description_is_safe(
+            option.get("label"), option.get("description")
+        )
+        for _, option in option_tokens
+    )
+    rendered: list[str] = []
+    for position, (token, option) in enumerate(option_tokens):
+        description = (
+            f'<span class="choice-desc">{_esc(option["description"])}</span>'
+            if show_descriptions
+            else ""
+        )
+        rendered.append(
+            f'<div class="choice"><input type="radio" name="answer" id="choice-{position}" value="{_esc(token)}"><label for="choice-{position}"><span class="choice-title">{_esc(option["label"])}</span>{description}</label></div>'
+        )
+    return "".join(rendered)
+
+
+def _choice_descriptions_allowed(spec: Mapping[str, Any]) -> bool:
+    try:
+        core.validate_choice_description_contract(spec)
+    except core.SpecError:
+        return False
+    return True
+
+
+def render_batch_question(
+    bundle: SessionBundle,
+    question: Mapping[str, Any],
+    index: int,
+    csrf: str,
+    question_token: str,
+    option_tokens: list[tuple[str, Mapping[str, Any]]],
+    nonce: str,
+) -> str:
+    core.validate_choice_label_contract(
+        bundle.spec, check_future_surfaces=False
+    )
+    total = len(bundle.spec["questions"])
+    area = next(item for item in bundle.cycle["areas"] if item["area_id"] == question["area_id"])
+    options = _render_choice_options(
+        option_tokens,
+        descriptions_allowed=_choice_descriptions_allowed(bundle.spec),
+    )
+    body = f"""
+{_progress(index,total)}<p class="eyebrow">{_esc(area['title'])}</p><h1>{_esc(question['title'])}</h1>
+<div class="scenario">{_esc(question['scenario_context'])}</div><p class="prompt">{_esc(question['prompt'])}</p>
+<fieldset class="choice-fieldset"><legend class="fine">選擇一個最符合目前情境的答案</legend><div class="choices">{options}</div></fieldset>
+<div class="actions"><button class="button" id="primary" type="button" disabled>提交答案</button></div><p id="status" class="status" role="status" aria-live="polite"></p>"""
+    script = f"""(()=>{{const button=document.getElementById('primary');const choices=[...document.querySelectorAll('input[name="answer"]')];const status=document.getElementById('status');{CHOICE_KEYBOARD_JS}button.addEventListener('click',async()=>{{const selected=choices.find(choice=>choice.checked);if(!selected)return;button.disabled=true;choices.forEach(choice=>choice.disabled=true);status.textContent='正在提交…';const payload={{request_id:{_json_script(secrets.token_hex(12))},question_token:{_json_script(question_token)},option_token:selected.value}};try{{const response=await fetch('/answer',{{method:'POST',headers:{{'Content-Type':'application/json','X-Mastery-Token':{_json_script(csrf)}}},body:JSON.stringify(payload)}});const page=await response.text();if(!response.ok)throw new Error(page);document.open();document.write(page);document.close();}}catch(error){{status.textContent='提交失敗，請重試。';button.disabled=false;choices.forEach(choice=>choice.disabled=false);}}}});}})();"""
+    return render_page(question["title"], bundle.phase, body, script, nonce)
+
+
+def render_batch_feedback(
+    bundle: SessionBundle,
+    question: Mapping[str, Any],
+    record: Mapping[str, Any],
+    index: int,
+    csrf: str,
+    next_token: str,
+    nonce: str,
+) -> str:
+    options = {item["id"]: item for item in question["options"]}
+    selected = options[record["selected_option_id"]]
+    correct = options[question["correct_option_id"]]
+    is_correct = bool(record["is_correct"])
+    if is_correct:
+        answer_cards = f'<section class="answer"><strong>你的答案 · 正確答案</strong><p>{_esc(correct["label"])}</p><p class="explanation">{_esc(correct["explanation"])}</p></section>'
+        answer_grid_class = ""
+    else:
+        answer_cards = f'<section class="answer"><strong>你的答案</strong><p>{_esc(selected["label"])}</p><p class="explanation">{_esc(selected["explanation"])}</p></section><section class="answer"><strong>正確答案</strong><p>{_esc(correct["label"])}</p><p class="explanation">{_esc(correct["explanation"])}</p></section>'
+        answer_grid_class = " answer-grid"
+    total = len(bundle.spec["questions"])
+    label = "回答正確" if is_correct else "這題需要補強"
+    sources = "".join(f"<li>{_esc(value)}</li>" for value in question["sources"])
+    body = f"""
+{_progress(index,total,feedback=True)}<div class="result {'correct' if is_correct else 'wrong'}" role="status" aria-live="polite"><h2>{'✓' if is_correct else '↗'} {label}</h2><p>{'你辨識出這個核心判準。' if is_correct else '先對齊判準，再繼續下一題。'}</p></div>
+<div class="{answer_grid_class.strip()}">{answer_cards}</div>
+<section class="notice"><strong>判準來源</strong><ul class="scope-list">{sources}</ul></section>
+<div class="actions"><button class="button" id="primary" type="button">{'查看總表' if index + 1 == total else '下一題'}</button></div><p id="status" class="status" role="status" aria-live="polite"></p>"""
+    script = _button_script(
+        "/next",
+        csrf,
+        {"request_id": secrets.token_hex(12), "next_token": next_token},
+        "primary",
+    )
+    return render_page(label, bundle.phase, body, script, nonce)
+
+
+def render_assessment_report(bundle: SessionBundle, report: Mapping[str, Any], nonce: str) -> str:
+    area_titles = {item["area_id"]: item["title"] for item in bundle.cycle["areas"]}
+    question_results = {item["question_id"]: item for item in report["question_results"]}
+    critical_gap_ids = set(report["critical_gap_ids"])
+    rows = []
+    for area in report["area_results"]:
+        questions = [item for item in bundle.spec["questions"] if item["area_id"] == area["area_id"]]
+        misses = [item for item in questions if not question_results[item["question_id"]]["is_correct"]]
+        gap_lines: list[str] = []
+        for item in misses:
+            prefix = "關鍵 · " if f"assessment.{item['question_id']}" in critical_gap_ids else ""
+            misconception = question_results[item["question_id"]].get("misconception_tag")
+            gap_lines.append(
+                f'<span>{prefix}{_esc(item["core_proposition"])}</span><br><span class="fine">{_esc(item["knowledge_kernel_id"])} · {_esc(misconception or "尚無 misconception 標籤")}</span>'
+            )
+        gap_copy = "<br>".join(gap_lines) or '<span class="fine">本輪沒有答錯題。</span>'
+        trace = ", ".join(item["question_id"] for item in questions)
+        rows.append(
+            f'<tr><td><strong>{_esc(area_titles[area["area_id"]])}</strong></td><td>{area["correct"]} / {area["total"]}</td><td><span class="signal {_esc(area["signal"])}">{_esc(area["signal_label"])}</span><br><span class="fine">信心：{_esc(area["confidence"])}</span></td><td>{gap_copy}</td><td>{area["suggested_slice_count"]} slices</td><td class="fine">{_esc(trace)}</td></tr>'
+        )
+    limitations = "".join(f"<li>{_esc(item)}</li>" for item in report["evidence_limitations"])
+    body = f"""
+<p class="eyebrow">評估完成</p><h1>你的知識訊號總表</h1><p class="lede">結果依主要領域聚合，供下一階段生成由簡到難的 Learning Slices。</p>
+<div class="summary"><div class="metric"><strong>{report['answered']}</strong><span>完成題數</span></div><div class="metric"><strong>{report['correct']}</strong><span>答對題數</span></div><div class="metric"><strong>{len(report['gaps'])}</strong><span>待補強核心</span></div></div>
+<div class="table-wrap"><table><thead><tr><th>領域</th><th>答對</th><th>訊號</th><th>關鍵缺口</th><th>建議學習量</th><th>題目追溯</th></tr></thead><tbody>{''.join(rows)}</tbody></table></div>
+<section class="notice"><h2>證據限制</h2><ul class="scope-list">{limitations}</ul></section><section class="notice"><strong>下一步</strong><p>請關閉此頁並回到 Codex。下一階段會依這份總表生成知識地圖。</p></section>"""
+    return render_page("評估總表", "assessment", body, "", nonce)
+
+
+def _flatten_slices(bundle: SessionBundle) -> list[str]:
+    return [slice_id for area in bundle.spec["areas"] for slice_id in area["slice_ids"]]
+
+
+def _learning_progress(bundle: SessionBundle) -> dict[str, Any]:
+    if bundle.slices is None:
+        raise core.SpecError("Learning Slice files are required")
+    return core.learning_completion_state(
+        bundle.phase_dir, bundle.spec, slices=bundle.slices
+    )
+
+
+def _assessment_status(bundle: SessionBundle, question_id: str) -> str:
+    report = bundle.assessment_report or {}
+    result = next(
+        (item for item in report.get("question_results", []) if item.get("question_id") == question_id),
+        None,
+    )
+    if result is None:
+        return "未出現在評估報告"
+    return "評估答對" if result.get("is_correct") else "評估待補強"
+
+
+def render_learning_map(
+    bundle: SessionBundle,
+    state: Mapping[str, Any],
+    *,
+    current_slice_id: str = "",
+    current_area_id: str = "",
+    current_clickable: bool = True,
+) -> str:
+    assert bundle.slices is not None
+    completed_slices = set(state["completed_slice_ids"])
+    completed_checks = set(state["completed_checkpoint_area_ids"])
+    areas_html: list[str] = []
+    for area in bundle.spec["areas"]:
+        nodes: list[str] = []
+        for position, slice_id in enumerate(area["slice_ids"], start=1):
+            item = bundle.slices[slice_id]
+            title = f"{position}. {item['title']}"
+            if slice_id in completed_slices:
+                nodes.append(
+                    f'<a class="node done" href="/slice/{_esc(slice_id)}" aria-label="已完成：{_esc(item["title"])}">✓ {_esc(title)}</a>'
+                )
+            elif slice_id == current_slice_id:
+                if current_clickable:
+                    nodes.append(
+                        f'<a class="node current" href="/slice/{_esc(slice_id)}" aria-current="step">{_esc(title)}</a>'
+                    )
+                else:
+                    nodes.append(
+                        f'<span class="node current" aria-current="step">{_esc(title)}</span>'
+                    )
+            else:
+                nodes.append(
+                    f'<span class="node locked" aria-label="尚未解鎖：{_esc(item["title"])}">鎖定 · {_esc(title)}</span>'
+                )
+        check_class = "done" if area["area_id"] in completed_checks else (
+            "current" if area["area_id"] == current_area_id else "locked"
+        )
+        check_prefix = "✓" if check_class == "done" else ("現在" if check_class == "current" else "鎖定")
+        nodes.append(
+            f'<span class="node checkpoint {check_class}">{check_prefix} · 領域檢核</span>'
+        )
+        areas_html.append(
+            f'<section class="map-area"><h3>{_esc(area["title"])}</h3><div class="nodes">{"".join(nodes)}</div></section>'
+        )
+    return f'<div class="map" aria-label="知識地圖">{"".join(areas_html)}</div>'
+
+
+def render_learning_intro(bundle: SessionBundle, csrf: str, nonce: str) -> str:
+    core.validate_visible_context_contract(
+        bundle.spec,
+        _learning_visible_choice_context(bundle),
+        allow_plain_option_labels=True,
+    )
+    state = _learning_progress(bundle)
+    first_slice = _flatten_slices(bundle)[0]
+    body = f"""
+<p class="eyebrow">知識地圖</p><h1>{_esc(bundle.spec['title'])}</h1>
+<p class="lede">依前置關係由簡到難前進；完成節點可以回看，後續節點會顯示位置並保持鎖定。</p>
+{render_learning_map(bundle,state,current_slice_id=first_slice,current_clickable=False)}
+<div class="meta"><span class="chip">{state['total_slices']} 個 Learning Slices</span><span class="chip">{state['total_checkpoints']} 次領域檢核</span><span class="chip">完成閱讀只計學習進度</span></div>
+<div class="actions"><button class="button" id="primary" type="button">開始學習</button></div><p id="status" class="status" role="status" aria-live="polite"></p>"""
+    script = _button_script("/start", csrf, {"request_id": secrets.token_hex(12)}, "primary")
+    return render_page(bundle.spec["title"], "learning", body, script, nonce)
+
+
+def render_learning_slice(
+    bundle: SessionBundle,
+    slice_id: str,
+    csrf: str,
+    slice_token: str,
+    nonce: str,
+    *,
+    reviewing: bool = False,
+) -> str:
+    assert bundle.slices is not None
+    item = bundle.slices[slice_id]
+    state = _learning_progress(bundle)
+    completed = slice_id in set(state["completed_slice_ids"])
+    flat = _flatten_slices(bundle)
+    index = flat.index(slice_id)
+    prerequisites = "".join(
+        f"<li>{_esc(bundle.slices[value]['title'])}</li>" for value in item["prerequisites"]
+    ) or "<li>無</li>"
+    links = "".join(
+        f"<li>{_esc(question_id)} · {_esc(_assessment_status(bundle, question_id))}</li>"
+        for question_id in item["assessment_question_ids"]
+    ) or "<li>本 slice 用於建立必要的基礎或跨領域連結。</li>"
+    boundaries = "".join(f"<li>{_esc(value)}</li>" for value in item["boundaries"])
+    mistakes = "".join(f"<li>{_esc(value)}</li>" for value in item["common_mistakes"])
+    takeaways = "".join(f"<li>{_esc(value)}</li>" for value in item["key_takeaways"])
+    sources = "".join(f"<li>{_esc(value)}</li>" for value in item["sources"])
+    controls = '<a class="back" href="/">← 回到目前進度</a>' if reviewing or completed else f'<div class="actions"><button class="button" id="primary" type="button">完成並繼續</button></div><p id="status" class="status" role="status" aria-live="polite"></p>'
+    script = ""
+    if not reviewing and not completed:
+        script = _button_script(
+            "/complete",
+            csrf,
+            {
+                "request_id": secrets.token_hex(12),
+                "slice_token": slice_token,
+            },
+            "primary",
+        )
+    completed_count = state["completed_slices"]
+    progress_html = f"""<div class="progress-row"><div class="progress-copy"><strong>知識地圖 · {index + 1} / {len(flat)}</strong><span>已完成 {completed_count} 個 slice · 剩餘 {len(flat) - completed_count} 個 slice</span></div></div><progress value="{completed_count}" max="{len(flat)}" aria-label="學習進度">{completed_count}/{len(flat)}</progress>"""
+    body = f"""
+{progress_html}
+<p class="eyebrow">{_esc(next(area['title'] for area in bundle.spec['areas'] if area['area_id'] == item['area_id']))} · {DIFFICULTY_LABELS[item['difficulty']]}</p><h1>{_esc(item['title'])}</h1>
+{render_learning_map(bundle,state,current_slice_id=slice_id)}
+<section class="lesson-section"><h2>你將能做到</h2><p>{_esc(item['learning_objective'])}</p><h3>前置知識</h3><ul>{prerequisites}</ul><h3>對應評估</h3><ul>{links}</ul></section>
+<section class="lesson-section"><h2>核心解釋</h2><p>{_esc(item['core_explanation'])}</p><h3>運作機制</h3><p>{_esc(item['mechanism'])}</p><h3>適用邊界</h3><ul>{boundaries}</ul></section>
+<section class="lesson-section"><h2>Worked example</h2><div class="callout"><strong>{_esc(item['worked_example']['scenario_context'])}</strong><p>{_esc(item['worked_example']['walkthrough'])}</p></div></section>
+<section class="lesson-section"><h2>常見錯誤</h2><ul>{mistakes}</ul></section>
+<section class="lesson-section takeaways"><h2>重點摘要</h2><ul>{takeaways}</ul></section>
+<section class="lesson-section source-list"><h2>來源</h2><ul>{sources}</ul></section>{controls}"""
+    return render_page(item["title"], "learning", body, script, nonce)
+
+
+def render_learning_checkpoint(
+    bundle: SessionBundle,
+    area_index: int,
+    csrf: str,
+    question_token: str,
+    option_tokens: list[tuple[str, Mapping[str, Any]]],
+    nonce: str,
+) -> str:
+    core.validate_choice_label_contract(
+        bundle.spec, check_future_surfaces=False
+    )
+    area = bundle.spec["areas"][area_index]
+    question = area["checkpoint"]
+    state = _learning_progress(bundle)
+    options = _render_choice_options(
+        option_tokens,
+        descriptions_allowed=_choice_descriptions_allowed(bundle.spec),
+    )
+    body = f"""
+<p class="eyebrow">形成性檢核 · {area_index + 1}/{len(bundle.spec['areas'])}</p><h1>{_esc(area['title'])}</h1>
+{render_learning_map(bundle,state,current_area_id=area['area_id'])}
+<div class="scenario">{_esc(question['scenario_context'])}</div><p class="prompt">{_esc(question['prompt'])}</p>
+<fieldset class="choice-fieldset"><legend class="fine">必須完成作答；答錯仍可前往下一領域</legend><div class="choices">{options}</div></fieldset>
+<div class="actions"><button class="button" id="primary" type="button" disabled>提交檢核</button></div><p id="status" class="status" role="status" aria-live="polite"></p>"""
+    script = f"""(()=>{{const button=document.getElementById('primary');const choices=[...document.querySelectorAll('input[name="answer"]')];const status=document.getElementById('status');{CHOICE_KEYBOARD_JS}button.addEventListener('click',async()=>{{const selected=choices.find(choice=>choice.checked);if(!selected)return;button.disabled=true;choices.forEach(choice=>choice.disabled=true);try{{const response=await fetch('/checkpoint-answer',{{method:'POST',headers:{{'Content-Type':'application/json','X-Mastery-Token':{_json_script(csrf)}}},body:JSON.stringify({{request_id:{_json_script(secrets.token_hex(12))},question_token:{_json_script(question_token)},option_token:selected.value}})}});const page=await response.text();if(!response.ok)throw new Error(page);document.open();document.write(page);document.close();}}catch(error){{status.textContent='提交失敗，請重試。';button.disabled=false;choices.forEach(choice=>choice.disabled=false);}}}});}})();"""
+    return render_page(question["title"], "learning", body, script, nonce)
+
+
+def render_learning_checkpoint_feedback(
+    bundle: SessionBundle,
+    area_index: int,
+    record: Mapping[str, Any],
+    csrf: str,
+    next_token: str,
+    nonce: str,
+) -> str:
+    area = bundle.spec["areas"][area_index]
+    question = area["checkpoint"]
+    options = {item["id"]: item for item in question["options"]}
+    selected = options[record["selected_option_id"]]
+    correct = options[question["correct_option_id"]]
+    is_correct = bool(record["is_correct"])
+    if is_correct:
+        cards = f'<section class="answer"><strong>你的答案 · 正確答案</strong><p>{_esc(correct["label"])}</p><p class="explanation">{_esc(correct["explanation"])}</p></section>'
+        card_class = ""
+    else:
+        cards = f'<section class="answer"><strong>你的答案</strong><p>{_esc(selected["label"])}</p><p class="explanation">{_esc(selected["explanation"])}</p></section><section class="answer"><strong>正確答案</strong><p>{_esc(correct["label"])}</p><p class="explanation">{_esc(correct["explanation"])}</p></section>'
+        card_class = "answer-grid"
+    last = area_index + 1 == len(bundle.spec["areas"])
+    sources = "".join(f"<li>{_esc(value)}</li>" for value in question["sources"])
+    body = f"""
+<p class="eyebrow">{_esc(area['title'])} · 檢核結果</p><div class="result {'correct' if is_correct else 'wrong'}" role="status" aria-live="polite"><h1>{'已掌握本次整合' if is_correct else '已找到一個複習重點'}</h1><p>{'這個結果會加入最終學習報告。' if is_correct else '答案已保存；你仍可繼續下一個領域。'}</p></div>
+<div class="{card_class}">{cards}</div><section class="notice"><strong>判準來源</strong><ul class="scope-list">{sources}</ul></section><div class="actions"><button class="button" id="primary" type="button">{'查看學習報告' if last else '下一領域'}</button></div><p id="status" class="status" role="status" aria-live="polite"></p>"""
+    script = _button_script(
+        "/checkpoint-next",
+        csrf,
+        {"request_id": secrets.token_hex(12), "next_token": next_token},
+        "primary",
+    )
+    return render_page("形成性檢核結果", "learning", body, script, nonce)
+
+
+def render_learning_report(bundle: SessionBundle, report: Mapping[str, Any], nonce: str) -> str:
+    area_titles = {item["area_id"]: item["title"] for item in bundle.cycle["areas"]}
+    results = {item["area_id"]: item for item in report["checkpoint_results"]}
+    rows = "".join(
+        f'<tr><td><strong>{_esc(area_titles[area["area_id"]])}</strong></td><td>{len(area["slice_ids"])} / {len(area["slice_ids"])}</td><td>{"通過" if results[area["area_id"]]["is_correct"] else "納入複習"}</td><td class="fine">{_esc(results[area["area_id"]].get("misconception_tag") or "—")}</td></tr>'
+        for area in bundle.spec["areas"]
+    )
+    body = f"""
+<p class="eyebrow">學習完成</p><h1>知識地圖已走完</h1><p class="lede">所有 slice 與領域檢核均已完成；下一份複習會融合評估缺口、檢核結果與重要正確觀念。</p>
+<div class="summary"><div class="metric"><strong>{report['completed_slices']}</strong><span>完成 Slices</span></div><div class="metric"><strong>{report['completed_checkpoints']}</strong><span>完成領域檢核</span></div><div class="metric"><strong>{len(report['gaps'])}</strong><span>檢核待複習</span></div></div>
+<div class="table-wrap"><table><thead><tr><th>領域</th><th>Slice 進度</th><th>檢核狀態</th><th>訊號</th></tr></thead><tbody>{rows}</tbody></table></div>
+<section class="notice"><strong>證據規則</strong><p>完成閱讀只更新學習進度；mastery 等級會依評估與新情境複習的可觀察證據判定。</p></section><section class="notice"><strong>下一步</strong><p>請關閉此頁並回到 Codex，使用這份報告產生全新情境的複習問答集。</p></section>"""
+    return render_page("學習報告", "learning", body, "", nonce)
+
+
+def render_review_report(bundle: SessionBundle, report: Mapping[str, Any], nonce: str) -> str:
+    corrected = report["corrected_gap_ids"]
+    remaining = report["remaining_gap_ids"]
+    new_errors = report["new_errors"]
+    reinforced = report["reinforced_concepts"]
+    delayed = report["delayed_review"]
+    not_directly_reviewed = report.get("not_directly_reviewed_gap_ids", [])
+    gap_map = {
+        item["gap_id"]: item
+        for source in (bundle.assessment_report or {}, bundle.learning_report or {})
+        for item in source.get("gaps", [])
+    }
+    new_gap_map = {f"review.{item['question_id']}": item for item in new_errors}
+
+    def gap_item(gap_id: str) -> str:
+        item = gap_map.get(gap_id, {})
+        proposition = item.get("core_proposition") or gap_id
+        return f'<li>{_esc(proposition)}<br><span class="fine">{_esc(gap_id)}</span></li>'
+
+    corrected_items = "".join(gap_item(value) for value in corrected) or "<li>本輪沒有可確認的修正訊號。</li>"
+    remaining_items = "".join(gap_item(value) for value in remaining) or "<li>沒有殘餘的既有缺口。</li>"
+    new_items = "".join(
+        f'<li>{_esc(item["core_proposition"])}<br><span class="fine">{_esc(item["knowledge_kernel_id"])} · {_esc(item.get("misconception_tag") or "新錯誤訊號")}</span></li>'
+        for item in new_errors
+    ) or "<li>沒有新暴露的錯誤。</li>"
+    reinforced_items = "".join(
+        f'<li>{_esc(item["core_proposition"])}<br><span class="fine">{_esc(item["knowledge_kernel_id"])} · 題目 {_esc(item["question_id"])}</span></li>'
+        for item in reinforced
+    ) or "<li>本輪未另列重要正確觀念。</li>"
+    coverage_notice = ""
+    if not_directly_reviewed:
+        coverage_items = "".join(
+            gap_item(value) for value in not_directly_reviewed
+        )
+        coverage_notice = f'<section class="notice"><h2>本輪未直接計分的缺口</h2><p>題數已達 15 題上限；以下核心已作為整合條件納入，但不據此宣稱已修正，並保留在延遲複習清單。</p><ul class="scope-list">{coverage_items}</ul></section>'
+    delayed_rows = "".join(
+        f'<tr><td>{_esc((gap_map.get(item["gap_id"]) or new_gap_map.get(item["gap_id"]) or {}).get("core_proposition") or item["gap_id"])}<br><span class="fine">{_esc(item["gap_id"])}</span></td><td>{_esc(item["due_date"])}</td><td>無提示</td></tr>'
+        for item in delayed
+    ) or '<tr><td colspan="3">沒有需要排入延遲複習的缺口。</td></tr>'
+    body = f"""
+<p class="eyebrow">複習完成</p><h1>修正、殘餘與新訊號</h1><p class="lede">這份報告將評估錯誤與複習表現逐一比較；本輪到此結束。</p>
+<div class="summary"><div class="metric"><strong>{len(corrected)}</strong><span>已修正缺口</span></div><div class="metric"><strong>{len(remaining)}</strong><span>殘餘缺口</span></div><div class="metric"><strong>{len(new_errors)}</strong><span>新暴露錯誤</span></div></div>
+<div class="grid"><section class="card"><h2>評估錯誤 → 複習修正</h2><ul class="scope-list">{corrected_items}</ul></section><section class="card"><h2>仍存在的缺口</h2><ul class="scope-list">{remaining_items}</ul></section><section class="card"><h2>新暴露的錯誤</h2><ul class="scope-list">{new_items}</ul></section><section class="card"><h2>已加深的重要觀念</h2><ul class="scope-list">{reinforced_items}</ul></section></div>
+{coverage_notice}
+<section class="notice"><h2>延遲複習清單</h2><div class="table-wrap"><table><thead><tr><th>缺口</th><th>日期</th><th>方式</th></tr></thead><tbody>{delayed_rows}</tbody></table></div><p class="fine">殘餘缺口預設排在完成日後三天；不在同一輪無限重考。</p></section>
+<section class="notice"><strong>本輪完成</strong><p>請關閉此頁並回到 Codex。報告與不可變作答紀錄已保留在 cycle workspace。</p></section>"""
+    return render_page("複習報告", "review", body, "", nonce)
+
+
+class SessionRuntime:
+    """Stateful UI shell over immutable v3 evidence files."""
+
+    def __init__(self, bundle: SessionBundle):
+        self.bundle = bundle
+        self.stop_requested = False
+        self.csrf = secrets.token_urlsafe(32)
+        self.nonce = secrets.token_urlsafe(18)
+        self._mutex = threading.RLock()
+        self._question_tokens = {
+            item["question_id"]: secrets.token_urlsafe(24)
+            for item in bundle.spec.get("questions", [])
+        }
+        self._option_tokens: dict[str, list[tuple[str, Mapping[str, Any]]]] = {
+            item["question_id"]: [
+                (secrets.token_urlsafe(18), option) for option in item["options"]
+            ]
+            for item in bundle.spec.get("questions", [])
+        }
+        self._next_tokens = {
+            item["question_id"]: secrets.token_urlsafe(24)
+            for item in bundle.spec.get("questions", [])
+        }
+        self._slice_tokens = {
+            slice_id: secrets.token_urlsafe(24)
+            for slice_id in (bundle.slices or {})
+        }
+        self._learning_question_tokens = {
+            area["area_id"]: secrets.token_urlsafe(24)
+            for area in bundle.spec.get("areas", [])
+        }
+        self._learning_option_tokens: dict[str, list[tuple[str, Mapping[str, Any]]]] = {
+            area["area_id"]: [
+                (secrets.token_urlsafe(18), option)
+                for option in area["checkpoint"]["options"]
+            ]
+            for area in bundle.spec.get("areas", [])
+        }
+        self._learning_next_tokens = {
+            area["area_id"]: secrets.token_urlsafe(24)
+            for area in bundle.spec.get("areas", [])
+        }
+        self.checkpoint_path = core.resolve_within(
+            bundle.cycle_dir, bundle.cycle_dir / "checkpoint.json"
+        )
+
+    def _save_checkpoint(self, screen: str, index: int = 0, subject_id: str = "") -> None:
+        core.atomic_write_json(
+            self.checkpoint_path,
+            {
+                "schema_version": 3,
+                "cycle_id": self.bundle.cycle["cycle_id"],
+                "phase": self.bundle.phase,
+                "screen": screen,
+                "index": index,
+                "subject_id": subject_id,
+                "updated_at": core.utc_now(),
+                "evidence_source": False,
+            },
+        )
+
+    @staticmethod
+    def _subject_for_token(tokens: Mapping[str, str], provided: Any) -> str | None:
+        for subject_id, expected in tokens.items():
+            if _same_token(provided, expected):
+                return subject_id
+        return None
+
+    @staticmethod
+    def _option_for_token(
+        options: list[tuple[str, Mapping[str, Any]]], provided: Any
+    ) -> Mapping[str, Any] | None:
+        for expected, option in options:
+            if _same_token(provided, expected):
+                return option
+        return None
+
+    def _checkpoint_consistent(self, value: Mapping[str, Any]) -> bool:
+        screen = value["screen"]
+        index = value["index"]
+        subject_id = value.get("subject_id", "")
+        if not isinstance(subject_id, str):
+            return False
+        if self.bundle.phase in {"assessment", "review"}:
+            questions = self.bundle.spec["questions"]
+            progress = core.response_completion_state(
+                self.bundle.phase_dir, self.bundle.spec
+            )
+            completed = progress["completed"]
+            sealed = (
+                core.validate_batch_manifest(
+                    self.bundle.phase_dir, self.bundle.spec
+                )
+                is not None
+            )
+            if screen == "intro":
+                return index == 0 and completed == 0 and not sealed
+            if screen == "question":
+                return (
+                    sealed
+                    and 0 <= index < len(questions)
+                    and completed == index
+                    and subject_id == questions[index]["question_id"]
+                )
+            if screen == "feedback":
+                return (
+                    sealed
+                    and 0 <= index < len(questions)
+                    and completed == index + 1
+                    and subject_id == questions[index]["question_id"]
+                )
+            if screen == "report":
+                return (
+                    sealed
+                    and progress["complete"]
+                    and index == len(questions) - 1
+                    and subject_id == questions[-1]["question_id"]
+                    and (self.bundle.phase_dir / "report.json").is_file()
+                )
+            return False
+
+        progress = _learning_progress(self.bundle)
+        completed_keys = progress["completed_event_keys"]
+        next_key = progress["next_event_key"]
+        areas = self.bundle.spec["areas"]
+        flat = _flatten_slices(self.bundle)
+        if screen == "intro":
+            return index == 0 and not completed_keys
+        if screen == "slice":
+            return (
+                0 <= index < len(flat)
+                and subject_id == flat[index]
+                and next_key == f"slice_completed:{flat[index]}"
+            )
+        if screen == "checkpoint":
+            return (
+                0 <= index < len(areas)
+                and subject_id == areas[index]["area_id"]
+                and next_key == f"checkpoint_answered:{areas[index]['area_id']}"
+            )
+        if screen == "checkpoint_feedback":
+            return (
+                0 <= index < len(areas)
+                and subject_id == areas[index]["area_id"]
+                and bool(completed_keys)
+                and completed_keys[-1]
+                == f"checkpoint_answered:{areas[index]['area_id']}"
+            )
+        if screen == "report":
+            return (
+                progress["complete"]
+                and index == len(areas) - 1
+                and subject_id == areas[-1]["area_id"]
+                and (self.bundle.phase_dir / "report.json").is_file()
+            )
+        return False
+
+    def _rebuild_checkpoint(self) -> dict[str, Any]:
+        if self.bundle.phase in {"assessment", "review"}:
+            questions = self.bundle.spec["questions"]
+            progress = core.response_completion_state(
+                self.bundle.phase_dir, self.bundle.spec
+            )
+            completed = progress["completed"]
+            sealed = (
+                core.validate_batch_manifest(
+                    self.bundle.phase_dir, self.bundle.spec
+                )
+                is not None
+            )
+            if completed == 0:
+                if sealed:
+                    return {
+                        "screen": "question",
+                        "index": 0,
+                        "subject_id": questions[0]["question_id"],
+                    }
+                return {"screen": "intro", "index": 0}
+            if progress["complete"]:
+                if (self.bundle.phase_dir / "report.json").is_file():
+                    return {
+                        "screen": "report",
+                        "index": len(questions) - 1,
+                        "subject_id": questions[-1]["question_id"],
+                    }
+                return {
+                    "screen": "feedback",
+                    "index": len(questions) - 1,
+                    "subject_id": questions[-1]["question_id"],
+                }
+            previous = questions[completed - 1]
+            return {
+                "screen": "feedback",
+                "index": completed - 1,
+                "subject_id": previous["question_id"],
+            }
+
+        progress = _learning_progress(self.bundle)
+        areas = self.bundle.spec["areas"]
+        flat = _flatten_slices(self.bundle)
+        completed_keys = progress["completed_event_keys"]
+        if not completed_keys:
+            return {"screen": "intro", "index": 0}
+        if progress["complete"]:
+            last_area = areas[-1]
+            if (self.bundle.phase_dir / "report.json").is_file():
+                return {
+                    "screen": "report",
+                    "index": len(areas) - 1,
+                    "subject_id": last_area["area_id"],
+                }
+            return {
+                "screen": "checkpoint_feedback",
+                "index": len(areas) - 1,
+                "subject_id": last_area["area_id"],
+            }
+        last_key = completed_keys[-1]
+        if last_key.startswith("checkpoint_answered:"):
+            area_id = last_key.split(":", 1)[1]
+            area_index = next(
+                index for index, area in enumerate(areas) if area["area_id"] == area_id
+            )
+            return {
+                "screen": "checkpoint_feedback",
+                "index": area_index,
+                "subject_id": area_id,
+            }
+        next_key = progress["next_event_key"]
+        if next_key and next_key.startswith("slice_completed:"):
+            slice_id = next_key.split(":", 1)[1]
+            return {
+                "screen": "slice",
+                "index": flat.index(slice_id),
+                "subject_id": slice_id,
+            }
+        if next_key and next_key.startswith("checkpoint_answered:"):
+            area_id = next_key.split(":", 1)[1]
+            area_index = next(
+                index for index, area in enumerate(areas) if area["area_id"] == area_id
+            )
+            return {
+                "screen": "checkpoint",
+                "index": area_index,
+                "subject_id": area_id,
+            }
+        raise UiError("Unable to reconstruct Learning position")
+
+    def _checkpoint(self) -> dict[str, Any]:
+        if self.checkpoint_path.is_file():
+            try:
+                value = core.read_json_object(self.checkpoint_path)
+            except core.SpecError:
+                value = {}
+            allowed_screens = {
+                "assessment": {"intro", "question", "feedback", "report"},
+                "review": {"intro", "question", "feedback", "report"},
+                "learning": {
+                    "intro",
+                    "slice",
+                    "checkpoint",
+                    "checkpoint_feedback",
+                    "report",
+                },
+            }[self.bundle.phase]
+            if (
+                value.get("schema_version") == 3
+                and value.get("cycle_id") == self.bundle.cycle["cycle_id"]
+                and value.get("phase") == self.bundle.phase
+                and value.get("screen") in allowed_screens
+                and isinstance(value.get("index"), int)
+                and not isinstance(value.get("index"), bool)
+                and self._checkpoint_consistent(value)
+            ):
+                return value
+        return self._rebuild_checkpoint()
+
+    def start(self, payload: Mapping[str, Any]) -> str:
+        self._require_request_id(payload)
+        with self._mutex:
+            state = self._checkpoint()
+            if state["screen"] == "intro":
+                if self.bundle.phase == "learning":
+                    core.validate_choice_description_contract(self.bundle.spec)
+                    first = _flatten_slices(self.bundle)[0]
+                    self._save_checkpoint("slice", 0, first)
+                else:
+                    core.ensure_batch_manifest(
+                        self.bundle.phase_dir, self.bundle.spec
+                    )
+                    self._save_checkpoint("question", 0, self.bundle.spec["questions"][0]["question_id"])
+            return self.render()
+
+    def scope_action(self, payload: Mapping[str, Any]) -> str:
+        self._require_request_id(payload)
+        action = payload.get("action")
+        if action not in {"adjust_scope", "pause"}:
+            raise UiError("Unknown scope action")
+        with self._mutex:
+            if self.bundle.phase != "assessment" or self._checkpoint()["screen"] != "intro":
+                raise UiError("Scope actions are available only before Assessment starts")
+            self.stop_requested = True
+            return render_scope_exit(self.bundle, str(action), self.nonce)
+
+    def answer(self, payload: Mapping[str, Any]) -> str:
+        request_id = self._require_request_id(payload)
+        with self._mutex:
+            question_id = self._subject_for_token(
+                self._question_tokens, payload.get("question_token")
+            )
+            if question_id is None:
+                raise UiError("Stale or future question token")
+            question = next(
+                item for item in self.bundle.spec["questions"] if item["question_id"] == question_id
+            )
+            selected = self._option_for_token(
+                self._option_tokens[question_id], payload.get("option_token")
+            )
+            if selected is None:
+                raise UiError("Unknown option token")
+            displayed_order = [
+                option["id"] for _, option in self._option_tokens[question_id]
+            ]
+            response_path = (
+                self.bundle.phase_dir / "responses" / f"{question_id}.json"
+            )
+            if response_path.is_file():
+                core.record_response(
+                    self.bundle.phase_dir,
+                    self.bundle.spec,
+                    question_id,
+                    selected["id"],
+                    displayed_order,
+                    request_id,
+                )
+                return self.render()
+            state = self._checkpoint()
+            if state.get("screen") != "question":
+                raise UiError("Answer is not available in the current state")
+            index = int(state.get("index", 0))
+            if self.bundle.spec["questions"][index]["question_id"] != question_id:
+                raise UiError("Stale or future question token")
+            core.record_response(
+                self.bundle.phase_dir,
+                self.bundle.spec,
+                question["question_id"],
+                selected["id"],
+                displayed_order,
+                request_id,
+            )
+            self._save_checkpoint("feedback", index, question["question_id"])
+            return self.render()
+
+    def next(self, payload: Mapping[str, Any]) -> str:
+        self._require_request_id(payload)
+        with self._mutex:
+            question_id = self._subject_for_token(
+                self._next_tokens, payload.get("next_token")
+            )
+            if question_id is None:
+                raise UiError("Stale or future next token")
+            questions = self.bundle.spec["questions"]
+            token_index = next(
+                index for index, item in enumerate(questions) if item["question_id"] == question_id
+            )
+            response_path = self.bundle.phase_dir / "responses" / f"{question_id}.json"
+            if not response_path.is_file():
+                raise UiError("Committed answer is missing")
+            state = self._checkpoint()
+            if state.get("screen") in {"question", "report"} and int(
+                state.get("index", 0)
+            ) > token_index:
+                return self.render()
+            if state.get("screen") == "report" and token_index == len(questions) - 1:
+                return self.render()
+            if state.get("screen") != "feedback":
+                raise UiError("Next is not available in the current state")
+            index = int(state.get("index", 0))
+            question = questions[index]
+            if question["question_id"] != question_id:
+                raise UiError("Stale or future next token")
+            if index + 1 < len(questions):
+                next_question = questions[index + 1]
+                self._save_checkpoint("question", index + 1, next_question["question_id"])
+            else:
+                self._persist_batch_report()
+                self._save_checkpoint("report", index, question["question_id"])
+            return self.render()
+
+    def complete_slice(self, payload: Mapping[str, Any]) -> str:
+        request_id = self._require_request_id(payload)
+        with self._mutex:
+            if self.bundle.phase != "learning" or self.bundle.slices is None:
+                raise UiError("Slice completion is unavailable")
+            slice_id = self._subject_for_token(
+                self._slice_tokens, payload.get("slice_token")
+            )
+            if slice_id is None:
+                raise UiError("Stale or future slice token")
+            event_path = (
+                self.bundle.phase_dir
+                / "events"
+                / f"slice_completed.{slice_id}.json"
+            )
+            if event_path.is_file():
+                core.record_slice_completion(
+                    self.bundle.phase_dir,
+                    self.bundle.spec,
+                    self.bundle.slices,
+                    slice_id,
+                    request_id,
+                )
+                return self.render()
+            state = self._checkpoint()
+            if state.get("screen") != "slice":
+                raise UiError("Slice completion is not available in the current state")
+            flat = _flatten_slices(self.bundle)
+            index = int(state.get("index", 0))
+            if flat[index] != slice_id:
+                raise UiError("Stale or future slice token")
+            core.record_slice_completion(
+                self.bundle.phase_dir,
+                self.bundle.spec,
+                self.bundle.slices,
+                slice_id,
+                request_id,
+            )
+            area_index = next(
+                position
+                for position, area in enumerate(self.bundle.spec["areas"])
+                if slice_id in area["slice_ids"]
+            )
+            area = self.bundle.spec["areas"][area_index]
+            if slice_id == area["slice_ids"][-1]:
+                self._save_checkpoint("checkpoint", area_index, area["area_id"])
+            else:
+                next_slice = flat[index + 1]
+                self._save_checkpoint("slice", index + 1, next_slice)
+            return self.render()
+
+    def answer_checkpoint(self, payload: Mapping[str, Any]) -> str:
+        request_id = self._require_request_id(payload)
+        with self._mutex:
+            if self.bundle.phase != "learning":
+                raise UiError("Learning checkpoint is unavailable")
+            area_id = self._subject_for_token(
+                self._learning_question_tokens, payload.get("question_token")
+            )
+            if area_id is None:
+                raise UiError("Stale or future checkpoint token")
+            area = next(
+                item for item in self.bundle.spec["areas"] if item["area_id"] == area_id
+            )
+            selected = self._option_for_token(
+                self._learning_option_tokens[area_id], payload.get("option_token")
+            )
+            if selected is None:
+                raise UiError("Unknown checkpoint option token")
+            displayed_order = [
+                option["id"] for _, option in self._learning_option_tokens[area_id]
+            ]
+            event_path = (
+                self.bundle.phase_dir
+                / "events"
+                / f"checkpoint_answered.{area_id}.json"
+            )
+            if event_path.is_file():
+                core.record_checkpoint_response(
+                    self.bundle.phase_dir,
+                    self.bundle.spec,
+                    area_id,
+                    selected["id"],
+                    displayed_order,
+                    request_id,
+                    slices=self.bundle.slices or {},
+                )
+                return self.render()
+            state = self._checkpoint()
+            if state.get("screen") != "checkpoint":
+                raise UiError("Checkpoint answer is not available in the current state")
+            area_index = int(state.get("index", 0))
+            if self.bundle.spec["areas"][area_index]["area_id"] != area_id:
+                raise UiError("Stale or future checkpoint token")
+            core.record_checkpoint_response(
+                self.bundle.phase_dir,
+                self.bundle.spec,
+                area_id,
+                selected["id"],
+                displayed_order,
+                request_id,
+                slices=self.bundle.slices or {},
+            )
+            self._save_checkpoint("checkpoint_feedback", area_index, area_id)
+            return self.render()
+
+    def next_checkpoint(self, payload: Mapping[str, Any]) -> str:
+        self._require_request_id(payload)
+        with self._mutex:
+            if self.bundle.phase != "learning":
+                raise UiError("Learning checkpoint is unavailable")
+            area_id = self._subject_for_token(
+                self._learning_next_tokens, payload.get("next_token")
+            )
+            if area_id is None:
+                raise UiError("Stale or future checkpoint-next token")
+            area_index = next(
+                index
+                for index, area in enumerate(self.bundle.spec["areas"])
+                if area["area_id"] == area_id
+            )
+            event_path = self.bundle.phase_dir / "events" / f"checkpoint_answered.{area_id}.json"
+            if not event_path.is_file():
+                raise UiError("Committed checkpoint answer is missing")
+            state = self._checkpoint()
+            if state.get("screen") in {"slice", "report"} and int(
+                state.get("index", 0)
+            ) > area_index:
+                return self.render()
+            if state.get("screen") == "report" and area_index == len(
+                self.bundle.spec["areas"]
+            ) - 1:
+                return self.render()
+            if state.get("screen") != "checkpoint_feedback":
+                raise UiError("Checkpoint next is not available in the current state")
+            area = self.bundle.spec["areas"][area_index]
+            if state.get("subject_id") != area_id:
+                raise UiError("Stale or future checkpoint-next token")
+            if area_index + 1 < len(self.bundle.spec["areas"]):
+                next_area = self.bundle.spec["areas"][area_index + 1]
+                next_slice = next_area["slice_ids"][0]
+                flat_index = _flatten_slices(self.bundle).index(next_slice)
+                self._save_checkpoint("slice", flat_index, next_slice)
+            else:
+                core.build_learning_report(
+                    self.bundle.phase_dir,
+                    self.bundle.spec,
+                    slices=self.bundle.slices or {},
+                    persist=True,
+                )
+                self._save_checkpoint("report", area_index, area["area_id"])
+            return self.render()
+
+    def view_slice(self, slice_id: str) -> str:
+        with self._mutex:
+            if self.bundle.phase != "learning" or self.bundle.slices is None:
+                raise UiError("Learning slice is unavailable")
+            if not core.ID_RE.fullmatch(slice_id) or slice_id not in self.bundle.slices:
+                raise UiError("Unknown learning slice")
+            state = _learning_progress(self.bundle)
+            completed = set(state["completed_slice_ids"])
+            current = self._checkpoint().get("subject_id", "")
+            if slice_id not in completed and slice_id != current:
+                raise UiError("Learning slice is still locked")
+            return render_learning_slice(
+                self.bundle,
+                slice_id,
+                self.csrf,
+                self._slice_tokens[slice_id],
+                self.nonce,
+                reviewing=slice_id in completed or slice_id != current,
+            )
+
+    def _persist_batch_report(self) -> dict[str, Any]:
+        if self.bundle.phase == "assessment":
+            return core.build_assessment_report(
+                self.bundle.phase_dir, self.bundle.spec, persist=True
+            )
+        if self.bundle.phase == "review":
+            assert self.bundle.assessment_report is not None
+            return core.build_review_report(
+                self.bundle.phase_dir,
+                self.bundle.spec,
+                self.bundle.assessment_report,
+                self.bundle.learning_report,
+                persist=True,
+            )
+        raise UiError("Batch report is unavailable for this phase")
+
+    @staticmethod
+    def _require_request_id(payload: Mapping[str, Any]) -> str:
+        value = payload.get("request_id")
+        if not isinstance(value, str) or not REQUEST_ID_RE.fullmatch(value):
+            raise UiError("Invalid request_id")
+        return value
+
+    def render(self) -> str:
+        with self._mutex:
+            state = self._checkpoint()
+            if self.bundle.phase == "assessment" and state["screen"] == "intro":
+                return render_assessment_intro(self.bundle, self.csrf, self.nonce)
+            if self.bundle.phase == "review" and state["screen"] == "intro":
+                return render_review_intro(self.bundle, self.csrf, self.nonce)
+            if self.bundle.phase == "learning":
+                if state["screen"] == "intro":
+                    return render_learning_intro(self.bundle, self.csrf, self.nonce)
+                if state["screen"] == "slice":
+                    flat = _flatten_slices(self.bundle)
+                    index = max(0, min(int(state.get("index", 0)), len(flat) - 1))
+                    slice_id = flat[index]
+                    return render_learning_slice(
+                        self.bundle,
+                        slice_id,
+                        self.csrf,
+                        self._slice_tokens[slice_id],
+                        self.nonce,
+                    )
+                if state["screen"] == "checkpoint":
+                    area_index = max(
+                        0,
+                        min(int(state.get("index", 0)), len(self.bundle.spec["areas"]) - 1),
+                    )
+                    area = self.bundle.spec["areas"][area_index]
+                    return render_learning_checkpoint(
+                        self.bundle,
+                        area_index,
+                        self.csrf,
+                        self._learning_question_tokens[area["area_id"]],
+                        self._learning_option_tokens[area["area_id"]],
+                        self.nonce,
+                    )
+                if state["screen"] == "checkpoint_feedback":
+                    area_index = max(
+                        0,
+                        min(int(state.get("index", 0)), len(self.bundle.spec["areas"]) - 1),
+                    )
+                    area = self.bundle.spec["areas"][area_index]
+                    path = self.bundle.phase_dir / "events" / f"checkpoint_answered.{area['area_id']}.json"
+                    return render_learning_checkpoint_feedback(
+                        self.bundle,
+                        area_index,
+                        core.read_json_object(path),
+                        self.csrf,
+                        self._learning_next_tokens[area["area_id"]],
+                        self.nonce,
+                    )
+                if state["screen"] == "report":
+                    report = core.build_learning_report(
+                        self.bundle.phase_dir,
+                        self.bundle.spec,
+                        slices=self.bundle.slices or {},
+                        persist=True,
+                    )
+                    return render_learning_report(self.bundle, report, self.nonce)
+                raise UiError(f"Unsupported learning UI state: {state['screen']}")
+            if self.bundle.phase not in {"assessment", "review"}:
+                raise UiError("Unsupported phase")
+            questions = self.bundle.spec["questions"]
+            index = max(0, min(int(state.get("index", 0)), len(questions) - 1))
+            question = questions[index]
+            if state["screen"] == "question":
+                return render_batch_question(
+                    self.bundle,
+                    question,
+                    index,
+                    self.csrf,
+                    self._question_tokens[question["question_id"]],
+                    self._option_tokens[question["question_id"]],
+                    self.nonce,
+                )
+            if state["screen"] == "feedback":
+                path = self.bundle.phase_dir / "responses" / f"{question['question_id']}.json"
+                record = core.read_json_object(path)
+                return render_batch_feedback(
+                    self.bundle,
+                    question,
+                    record,
+                    index,
+                    self.csrf,
+                    self._next_tokens[question["question_id"]],
+                    self.nonce,
+                )
+            if state["screen"] == "report":
+                report = self._persist_batch_report()
+                if self.bundle.phase == "assessment":
+                    return render_assessment_report(self.bundle, report, self.nonce)
+                return render_review_report(self.bundle, report, self.nonce)
+            raise UiError(f"Unsupported UI state: {state['screen']}")
+
+
+def make_handler(runtime: SessionRuntime) -> type[BaseHTTPRequestHandler]:
+    class Handler(BaseHTTPRequestHandler):
+        server_version = "MasterySession/3.0"
+
+        def _headers(self, status: int, content_type: str, length: int) -> None:
+            self.send_response(status)
+            self.send_header("Content-Type", content_type)
+            self.send_header("Content-Length", str(length))
+            self.send_header("Cache-Control", "no-store")
+            self.send_header("Content-Security-Policy", f"default-src 'none'; style-src 'nonce-{runtime.nonce}'; script-src 'nonce-{runtime.nonce}'; connect-src 'self'; img-src 'self' data:; base-uri 'none'; form-action 'self'; frame-ancestors 'none'")
+            self.send_header("X-Frame-Options", "DENY")
+            self.send_header("X-Content-Type-Options", "nosniff")
+            self.send_header("Referrer-Policy", "no-referrer")
+            self.end_headers()
+
+        def _send(self, body: str, status: int = 200, content_type: str = "text/html; charset=utf-8") -> None:
+            encoded = body.encode("utf-8")
+            self._headers(status, content_type, len(encoded))
+            self.wfile.write(encoded)
+
+        def _host_allowed(self) -> bool:
+            host = self.headers.get("Host", "").rsplit(":", 1)[0].strip("[]").lower()
+            return host in {"127.0.0.1", "localhost", "::1"}
+
+        def _origin_allowed(self) -> bool:
+            if self.headers.get("Sec-Fetch-Site", "").lower() == "cross-site":
+                return False
+            origin = self.headers.get("Origin")
+            if origin is None:
+                return True
+            expected = f"http://{self.headers.get('Host', '').lower()}"
+            return hmac.compare_digest(origin.rstrip("/").lower(), expected)
+
+        def _touch_activity(self) -> None:
+            tracker = getattr(self.server, "activity_timeout", None)
+            if tracker is not None:
+                tracker.touch()
+
+        def do_GET(self) -> None:  # noqa: N802
+            if not self._host_allowed():
+                self._send("Host rejected", 403, "text/plain; charset=utf-8")
+                return
+            self._touch_activity()
+            if self.path.startswith("/slice/"):
+                try:
+                    self._send(runtime.view_slice(self.path[len("/slice/") :]))
+                except (core.SpecError, core.IncompletePhaseError, UiError) as exc:
+                    self._send(f"無法載入學習節點：{_esc(exc)}", 409)
+                return
+            if self.path != "/":
+                self._send("Not found", 404, "text/plain; charset=utf-8")
+                return
+            try:
+                self._send(runtime.render())
+            except (core.SpecError, core.IncompletePhaseError, UiError) as exc:
+                self._send(f"無法載入目前階段：{_esc(exc)}", 409)
+            except OSError as exc:
+                self._send(f"儲存系統暫時無法使用：{_esc(exc)}", 500)
+
+        def do_POST(self) -> None:  # noqa: N802
+            if not self._host_allowed():
+                self._send("Host rejected", 403, "text/plain; charset=utf-8")
+                return
+            if not self._origin_allowed():
+                self._send("Origin rejected", 403, "text/plain; charset=utf-8")
+                return
+            if not _same_token(self.headers.get("X-Mastery-Token"), runtime.csrf):
+                self._send("CSRF rejected", 403, "text/plain; charset=utf-8")
+                return
+            self._touch_activity()
+            content_type = self.headers.get("Content-Type", "").split(";", 1)[0].strip().lower()
+            if content_type != "application/json":
+                self._send("JSON required", 415, "text/plain; charset=utf-8")
+                return
+            try:
+                size = int(self.headers.get("Content-Length", "0"))
+            except ValueError:
+                self._send("Invalid body length", 400, "text/plain; charset=utf-8")
+                return
+            if size < 0 or size > MAX_BODY_BYTES:
+                self._send("Body too large", 413, "text/plain; charset=utf-8")
+                return
+            try:
+                payload = json.loads(self.rfile.read(size).decode("utf-8"))
+                if not isinstance(payload, dict):
+                    raise ValueError("payload must be an object")
+                actions: dict[str, Callable[[Mapping[str, Any]], str]] = {
+                    "/start": runtime.start,
+                    "/scope-action": runtime.scope_action,
+                    "/answer": runtime.answer,
+                    "/next": runtime.next,
+                    "/complete": runtime.complete_slice,
+                    "/checkpoint-answer": runtime.answer_checkpoint,
+                    "/checkpoint-next": runtime.next_checkpoint,
+                }
+                action = actions.get(self.path)
+                if action is None:
+                    self._send("Not found", 404, "text/plain; charset=utf-8")
+                    return
+                page = action(payload)
+                self._send(page)
+                if runtime.stop_requested or runtime._checkpoint().get("screen") == "report":
+                    threading.Thread(target=self.server.shutdown, daemon=True).start()
+            except core.ConflictError as exc:
+                self._send(f"Conflict: {_esc(exc)}", 409, "text/plain; charset=utf-8")
+            except (UnicodeDecodeError, json.JSONDecodeError, ValueError, core.SpecError, core.IncompletePhaseError, UiError) as exc:
+                self._send(f"Request rejected: {_esc(exc)}", 400, "text/plain; charset=utf-8")
+            except OSError as exc:
+                self._send(
+                    f"Storage unavailable: {_esc(exc)}",
+                    500,
+                    "text/plain; charset=utf-8",
+                )
+
+        def log_message(self, format: str, *args: Any) -> None:
+            return
+
+    return Handler
+
+
+class ActivityTimeout:
+    """Reset a server shutdown deadline after every accepted local request."""
+
+    def __init__(self, server: ThreadingHTTPServer, seconds: int):
+        self.server = server
+        self.seconds = seconds
+        self._timer: threading.Timer | None = None
+        self._mutex = threading.Lock()
+
+    def touch(self) -> None:
+        if self.seconds <= 0:
+            return
+        with self._mutex:
+            if self._timer is not None:
+                self._timer.cancel()
+            self._timer = threading.Timer(self.seconds, self.server.shutdown)
+            self._timer.daemon = True
+            self._timer.start()
+
+    def cancel(self) -> None:
+        with self._mutex:
+            if self._timer is not None:
+                self._timer.cancel()
+                self._timer = None
+
+
+def _validate_phase_state(bundle: SessionBundle) -> dict[str, Any]:
+    core.validate_phase_write_surface(
+        bundle.cycle_dir, bundle.phase_dir, bundle.phase
+    )
+    if bundle.phase in {"assessment", "review"}:
+        manifest = core.validate_batch_manifest(bundle.phase_dir, bundle.spec)
+        progress = core.response_completion_state(bundle.phase_dir, bundle.spec)
+        if progress["complete"]:
+            return progress
+        core.validate_visible_context_contract(
+            bundle.spec,
+            _cycle_visible_choice_context(bundle.cycle),
+            allow_plain_option_labels=True,
+        )
+        if manifest is None:
+            core.validate_choice_description_contract(bundle.spec)
+        else:
+            core.validate_choice_label_contract(
+                bundle.spec, check_future_surfaces=False
+            )
+        return progress
+    progress = core.learning_completion_state(
+        bundle.phase_dir,
+        bundle.spec,
+        slices=bundle.slices or {},
+    )
+    if not progress["complete"]:
+        core.validate_visible_context_contract(
+            bundle.spec,
+            _learning_visible_choice_context(bundle),
+            allow_plain_option_labels=True,
+        )
+    if not progress["completed_event_keys"]:
+        core.validate_choice_description_contract(bundle.spec)
+    elif not progress["complete"]:
+        core.validate_choice_label_contract(
+            bundle.spec, check_future_surfaces=False
+        )
+    return progress
+
+
+def command_validate(workspace: Path, cycle_ref: str, phase: str) -> int:
+    bundle = load_phase_bundle(workspace, cycle_ref, phase)
+    progress = _validate_phase_state(bundle)
+    result = {
+        "ok": True,
+        "schema_version": 3,
+        "cycle_id": bundle.cycle["cycle_id"],
+        "phase": phase,
+    }
+    if phase in {"assessment", "review"}:
+        result["questions"] = len(bundle.spec["questions"])
+        result["answered"] = progress["completed"]
+        result["complete"] = progress["complete"]
+    if phase == "learning":
+        result["areas"] = len(bundle.spec["areas"])
+        result["slices"] = sum(len(area["slice_ids"]) for area in bundle.spec["areas"])
+        result["completed_slices"] = progress["completed_slices"]
+        result["complete"] = progress["complete"]
+    print(json.dumps(result, ensure_ascii=False))
+    return 0
+
+
+def _create_server(runtime: SessionRuntime, port: int) -> ThreadingHTTPServer:
+    server = ThreadingHTTPServer(("127.0.0.1", port), make_handler(runtime))
+    # server_close() must join live request handlers before the PhaseLock exits.
+    server.daemon_threads = False
+    server.block_on_close = True
+    return server
+
+
+def command_serve(
+    workspace: Path,
+    cycle_ref: str,
+    phase: str,
+    port: int,
+    idle_timeout: int,
+) -> int:
+    bundle = load_phase_bundle(workspace, cycle_ref, phase)
+    with core.PhaseLock(bundle.cycle_dir, phase):
+        _validate_phase_state(bundle)
+        runtime = SessionRuntime(bundle)
+        server = _create_server(runtime, port)
+        activity_timeout = ActivityTimeout(server, idle_timeout)
+        setattr(server, "activity_timeout", activity_timeout)
+        url = f"http://127.0.0.1:{server.server_address[1]}/"
+        print(
+            json.dumps(
+                {
+                    "ready": True,
+                    "schema_version": 3,
+                    "cycle_id": bundle.cycle["cycle_id"],
+                    "phase": phase,
+                    "url": url,
+                    "idle_timeout_seconds": idle_timeout,
+                },
+                ensure_ascii=False,
+            ),
+            flush=True,
+        )
+        activity_timeout.touch()
+        try:
+            server.serve_forever(poll_interval=0.1)
+        except KeyboardInterrupt:
+            pass
+        finally:
+            activity_timeout.cancel()
+            server.server_close()
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Validate or serve a Mastery Loop v3 phase.")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    for name in ("validate", "serve"):
+        subparser = subparsers.add_parser(name)
+        subparser.add_argument("--workspace", required=True)
+        subparser.add_argument("--cycle", required=True)
+        subparser.add_argument("--phase", required=True, choices=sorted(core.PHASES))
+        if name == "serve":
+            subparser.add_argument("--port", type=int, default=0)
+            subparser.add_argument("--idle-timeout", type=int, default=1800)
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    try:
+        raw_workspace = Path(args.workspace).expanduser()
+        workspace = core.resolve_within(raw_workspace, raw_workspace)
+        if args.command == "validate":
+            return command_validate(workspace, args.cycle, args.phase)
+        return command_serve(
+            workspace,
+            args.cycle,
+            args.phase,
+            args.port,
+            args.idle_timeout,
+        )
+    except (core.SpecError, core.ConflictError, core.IncompletePhaseError, OSError) as exc:
+        print(json.dumps({"ok": False, "error": str(exc)}, ensure_ascii=False), file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/weeks/2026/2026-w35-mastery-loop/completed/mastery-loop/scripts/session_core.py
+++ b/weeks/2026/2026-w35-mastery-loop/completed/mastery-loop/scripts/session_core.py
@@ -1,0 +1,3294 @@
+#!/usr/bin/env python3
+"""Pure-data core for Mastery Loop v3 sessions.
+
+This module owns validation, immutable evidence records, derived reports, and
+the learning-completion gate.  It intentionally contains no HTTP or HTML code
+so the local UI can be tested independently from the evidence model.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+import difflib
+import hashlib
+import json
+import os
+import re
+import secrets
+import tempfile
+import unicodedata
+from collections import Counter
+from pathlib import Path
+from typing import Any, Iterable, Mapping
+
+
+ID_RE = re.compile(r"^[a-z0-9][a-z0-9._-]{0,127}$")
+PHASES = {"assessment", "learning", "review"}
+GOAL_INTENTS = {"end_to_end_delivery", "diagnose_improve", "review_teach"}
+BENCHMARK_STATUSES = {"verified", "partially_verified", "provisional"}
+V3_ARTIFACT_PATHS = {
+    "assessment_spec": "assessment/spec.json",
+    "assessment_report": "assessment/report.json",
+    "learning_path": "learning/path.json",
+    "learning_report": "learning/report.json",
+    "review_spec": "review/spec.json",
+    "review_report": "review/report.json",
+}
+QUESTION_FAMILIES = {
+    "recognition",
+    "explanation",
+    "prediction",
+    "application",
+    "critique",
+    "compare",
+    "threshold",
+    "tradeoff",
+    "transfer",
+    "counterevidence",
+    "postmortem",
+    "calibration",
+    "sequence",
+}
+DIFFICULTIES = {"foundation", "core", "advanced"}
+SIGNAL_LABELS = {
+    "stable_signal": "穩定訊號",
+    "mixed_signal": "混合訊號",
+    "needs_support": "待補強",
+}
+ANSWER_REVEAL_PATTERNS = tuple(
+    re.compile(pattern, re.IGNORECASE)
+    for pattern in (
+        r"(?:正確|正解|最佳|標準)(?:的)?\s*(?:答案|選項|作法|做法|方案|策略)",
+        r"(?:這|此)(?:一|個)?選項.{0,16}(?:正確|最佳|最符合)",
+        r"符合.{0,16}(?:本題|這一題|題意|核心命題|正確判準)",
+        r"(?:完整|完全)(?:回答|符合|滿足).{0,16}(?:本題|這一題|題目|問題|命題)",
+        r"(?:首選|推薦|建議採用|最合適|最恰當)(?:的)?\s*(?:答案|選項|作法|做法|方案|策略)",
+        r"(?:這|此)(?:個|一個)?(?:答案|選項|作法|做法|方案|策略)?.{0,8}(?:應|該|應該)(?:被)?(?:選擇|選取|採用)",
+        r"(?:應|該|應該)(?:選擇|選取|採用).{0,8}(?:這|此)(?:個|一個)?(?:答案|選項|作法|做法|方案|策略)?",
+        r"(?:請|直接)(?:選|選擇|選取|採用)(?:這|此)(?:個|一個|項)?(?:答案|選項|作法|做法|方案|策略)?",
+        r"答案.{0,4}(?:就在|就是|位於)(?:這|此)(?:個|一個|項)?(?:答案|選項|作法|做法|方案|策略)?",
+        r"(?:它|這|此).{0,4}(?:就是|即為)(?:正確)?答案(?:[。！!；;]|$)",
+        r"唯一.{0,8}(?:合理|可行|有效|安全|符合).{0,8}(?:答案|選項|作法|做法|方案|策略)",
+        r"\b(?:correct|right|best|ideal|preferred|recommended)\s+(?:answer|option|choice|approach|action|response|solution|strategy)\b",
+        r"\bthis\s+one\s+is\s+(?:correct|right|best|preferred)\b",
+        r"\b(?:correct|right|best|preferred)\s+one\b",
+        r"(?:這|此)(?:一)?個才?(?:對|正確|最好)",
+        r"\bthis\s+(?:answer|option|choice|approach|action|response|solution|strategy)\s+(?:is|should\s+be|must\s+be)\s+(?:correct|right|best|preferred|recommended|selected|chosen|used)\b",
+        r"\bshould\s+be\s+(?:selected|chosen)\b",
+        r"\b(?:select|choose)\s+(?:this|the)\s+(?:answer|option|choice|approach|action|response|solution|strategy)\b",
+        r"\b(?:select|choose|pick)\s+(?:this|the)(?:\s+(?:answer|option|choice|approach|action|response|solution|strategy))?\b",
+        r"\b(?:select|choose|pick)\s+me\b",
+        r"(?:選|選擇|選取|採用)我(?:[。！!；;]|$)",
+        r"\bthis\s+is\s+(?:the\s+)?(?:(?:correct|right|best|preferred|recommended)\s+)?(?:answer|option|choice)\b",
+        r"\b(?:only|uniquely)\s+(?:defensible|valid|acceptable|safe)\s+(?:answer|option|choice|approach|action|response|solution|strategy)\b",
+        r"\bmatches?\s+(?:this|the)\s+(?:question|prompt|core proposition|answer key)\b",
+        r"\bfully\s+(?:answers|satisfies)\s+(?:this|the)\s+(?:question|prompt|proposition)\b",
+        r"\b(?:meets?|satisfies|fulfills?|matches?|answers?|aligns?\s+with).{0,24}(?:prompt|question|stated\s+(?:condition|criterion|requirement))\b",
+        r"(?:符合|滿足|回答|對齊).{0,16}(?:本題|題目|問題|題述|所述)(?:條件|判準|要求)?",
+        r"\bthe\s+answer\b|^\s*answer\s*[.!;:]?\s*$",
+        r"^\s*(?:答案|正解)\s*[。！!；;]?\s*$",
+        r"\b(?:status|result|grade|score|verdict)\s*[:=\-]\s*(?:pass(?:ed)?|fail(?:ed)?|correct|incorrect|right|wrong|full\s+credit|perfect(?:\s+score)?)\b",
+        r"\b(?:earns?|gets?|receives?|deserves?)\s+(?:full\s+credit|a\s+perfect\s+score)\b",
+        r"\b(?:meets?|satisfies?)\s+(?:all|every)\s+(?:stated\s+)?(?:requirement|requirements|condition|conditions|criterion|criteria|prerequisite|prerequisites|gate|gates)\b",
+        r"\b(?:all|every)\s+(?:stated\s+)?(?:requirement|requirements|condition|conditions|criterion|criteria|prerequisite|prerequisites|gate|gates)\s+(?:is|are|has\s+been|have\s+been)?\s*(?:met|satisfied|passed)\b",
+        r"\b(?:no|without)\s+(?:remaining\s+|unresolved\s+)?(?:gap|gaps|omission|omissions)\b",
+        r"^\s*(?:pass(?:ed)?|fail(?:ed)?|full\s+credit|perfect\s+score)\s*[.!]?\s*$",
+        r"\b(?:earns?|gets?|receives?|deserves?)\s+(?:the\s+)?(?:maximum|highest|perfect)\s+(?:score|grade|credit)\b",
+        r"\b(?:guaranteed|certain|sure)\s+to\s+pass\b",
+        r"(?:狀態|結果|評分|成績|判定)\s*[:：=—-]?\s*(?:通過|合格|不合格|正確|錯誤|滿分|零分)",
+        r"(?:可|會|應)?(?:得|獲得|拿到)\s*(?:滿分|完整分數|全分)",
+        r"(?:保證|必定|肯定|一定)(?:可以|會)?(?:通過|合格|得分)",
+        r"(?:獲得|拿到|得到)(?:最高|最佳)(?:分數|評分|成績)",
+        r"(?:全部|所有|每個).{0,8}(?:條件|要求|判準|前提|門檻).{0,8}(?:皆|均|都)?(?:已)?(?:滿足|符合|通過|成立)",
+        r"(?:沒有|無)(?:任何)?(?:未解決|尚未處理|剩餘)?(?:的)?(?:缺口|遺漏)",
+        r"(?:這|此)(?:個)?(?:說法|選項|答案|作法|做法|方案|策略)?.{0,8}(?:已)?(?:涵蓋|包含).{0,12}(?:題目|問題)?.{0,8}(?:所有|全部)(?:必要)?(?:機制|要點|條件|要求|面向)",
+        r"(?:已)?(?:全面|完整地|完全|綜合地)(?:涵蓋|包含|回答|滿足).{0,16}(?:題目|問題|要求|機制|要點|條件)",
+        r"\b(?:covers?|includes?)\s+(?:all|every)\s+(?:required\s+|necessary\s+)?(?:mechanism|mechanisms|point|points|condition|conditions|requirement|requirements|aspect|aspects)\b",
+        r"\b(?:comprehensively|completely|fully)\s+(?:covers?|includes?|answers?|satisfies?)\b",
+        r"^\s*(?:通過|合格|不合格|滿分|零分)\s*[。！!]?\s*$",
+        r"[✅✔☑⭐🌟🏆💯👍🎯❌✗✘🚫]",
+    )
+)
+QUESTION_ANSWER_REVEAL_PATTERNS = tuple(
+    re.compile(pattern, re.IGNORECASE)
+    for pattern in (
+        r"\b(?:the\s+)?(?:first|second|third|fourth|fifth|1st|2nd|3rd|4th|5th|[a-e])\s+(?:answer|option|choice|response|approach)\s+(?:is|would\s+be|must\s+be)\s+(?:the\s+)?(?:correct|right|best|preferred|recommended)\b",
+        r"\b(?:correct|right|best|preferred|recommended)\s+(?:answer|option|choice|response|approach)\s+(?:is|would\s+be)\s+(?:the\s+)?(?:first|second|third|fourth|fifth|1st|2nd|3rd|4th|5th|[a-e])\b",
+        r"\b(?:answer|option|choice|response|approach)\s*(?:[a-e]|[1-5])\s+(?:is|would\s+be|must\s+be)\s+(?:the\s+)?(?:correct|right|best|preferred|recommended)\b",
+        r"\b(?:answer|option|choice|response|approach)\s*(?:[a-e]|[1-5])\b.{0,32}\b(?:answer|correct|right|best|preferred|recommended|full\s+credit|pass(?:ed)?)\b",
+        r"第\s*[一二三四五1-5]\s*(?:個|項)?\s*(?:答案|選項|作法|做法|方案|策略).{0,8}(?:是|為|即為).{0,4}(?:正確|正解|最佳|首選|推薦)",
+        r"(?:正確|正解|最佳|首選|推薦)(?:的)?\s*(?:答案|選項|作法|做法|方案|策略).{0,8}(?:是|為|即為)\s*第\s*[一二三四五1-5]",
+        r"(?:答案|選項|作法|做法|方案|策略)\s*[A-Ea-e1-5].{0,8}(?:是|為|即為).{0,4}(?:正確|正解|最佳|首選|推薦)",
+        r"(?:答案|選項|作法|做法|方案|策略)\s*[A-Ea-e1-5].{0,24}(?:答案|正確|正解|最佳|首選|推薦|滿分|通過)",
+        r"\b(?:answer|option|choice|response|approach)\s+(?:shown\s+|listed\s+|presented\s+|displayed\s+)?(?:first|second|third|fourth|fifth|1st|2nd|3rd|4th|5th)\s+(?:earns?|gets?|receives?|deserves?|is)\s+(?:the\s+)?(?:correct|right|best|preferred|recommended|full\s+credit)\b",
+        r"\b(?:the\s+)?(?:top|uppermost|bottom|last|leftmost|rightmost)\s+(?:answer|option|choice|response|approach)\s+(?:is|contains?|earns?|gets?|receives?)\s+(?:the\s+)?(?:answer|correct|right|best|preferred|recommended|full\s+credit)\b",
+        r"(?:最上方|最下方|最左側|最右側|最後)(?:的)?(?:答案|選項|作法|做法|方案|策略).{0,8}(?:是|為|即為|包含).{0,4}(?:答案|正確|正解|最佳|首選|推薦)",
+    )
+)
+BOUNDARY_SIGNAL_PATTERN = re.compile(
+    r"\b(?:only|but|unless|except|without|before|after|requires?|depends?|remains?|unresolved|outside|separate|excludes?|omits?|limited|boundary|prerequisite|tradeoff|condition|scope)\b|"
+    r"(?:只|僅|但|尚未|未涵蓋|不含|除非|需要|必須|前提|條件|取捨|代價|限制|邊界|遺漏|仍|才|若|依賴|適用範圍|另行|之外)",
+    re.IGNORECASE,
+)
+VISIBLE_CONTEXT_ANSWER_CUE_PATTERN = re.compile(
+    r"\b(?:answer\s+key|correct\s+answer|right\s+answer|best\s+(?:answer|option)|preferred\s+choice|select\s+this|choose\s+this)\b|"
+    r"\b(?:correct|right|best)\s*[:=\-]|"
+    r"(?:答案\s*(?:是|為|[:：])|(?:正確|正解|最佳)\s*[:：=]|正確答案|正確選項|最佳答案|最佳選項|請選這個)",
+    re.IGNORECASE,
+)
+OWN_LABEL_CUE_PATTERN = re.compile(
+    r"\b(?:required\s+next\s+action|proceed\s+with|use|select|choose|pick|avoid|reject|exclude|do\s+not\s+choose)\b|"
+    r"(?:下一步|採用|選擇|選取|避免|不要選|排除|拒絕)",
+    re.IGNORECASE,
+)
+ANSWER_LIKE_LABEL_PATTERN = re.compile(
+    r"\b(?:use|validate|verify|block|inspect|continue|infer|apply|run|stop|choose|select|calculate|compare|confirm|publish|retry)\b|"
+    r"(?:先|應|必須|需要|檢查|驗證|阻擋|執行|採用|選擇|推論|判斷|依據|比較|計算|確認|發布|重試)",
+    re.IGNORECASE,
+)
+SHORT_STABLE_TOKEN_STOPWORDS = {
+    "a",
+    "an",
+    "and",
+    "as",
+    "at",
+    "be",
+    "by",
+    "if",
+    "in",
+    "is",
+    "it",
+    "of",
+    "on",
+    "or",
+    "the",
+    "to",
+}
+
+
+class SpecError(ValueError):
+    """Raised when a v3 specification violates the session contract."""
+
+
+class ConflictError(RuntimeError):
+    """Raised when immutable state already exists with different intent."""
+
+
+class IncompletePhaseError(RuntimeError):
+    """Raised when a derived report requires a phase that is not complete."""
+
+
+class IncompleteLearningError(IncompletePhaseError):
+    """Raised when Review is requested before every learning gate is complete."""
+
+
+def utc_now() -> str:
+    return dt.datetime.now(dt.timezone.utc).isoformat()
+
+
+def _nonempty(value: Any, field: str, maximum: int = 2000) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise SpecError(f"{field} must be a non-empty string")
+    cleaned = value.strip()
+    if len(cleaned) > maximum:
+        raise SpecError(f"{field} exceeds {maximum} characters")
+    return cleaned
+
+
+def _optional(value: Any, field: str, maximum: int = 2000) -> str:
+    if value in (None, ""):
+        return ""
+    if not isinstance(value, str):
+        raise SpecError(f"{field} must be a string")
+    cleaned = value.strip()
+    if len(cleaned) > maximum:
+        raise SpecError(f"{field} exceeds {maximum} characters")
+    return cleaned
+
+
+def _rfc3339(value: Any, field: str) -> str:
+    cleaned = _nonempty(value, field, 100)
+    try:
+        parsed = dt.datetime.fromisoformat(cleaned.replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise SpecError(f"{field} must be an RFC-3339 timestamp") from exc
+    if parsed.tzinfo is None or parsed.utcoffset() is None:
+        raise SpecError(f"{field} must include a timezone")
+    return cleaned
+
+
+def _identifier(value: Any, field: str) -> str:
+    cleaned = _nonempty(value, field, 128)
+    if not ID_RE.fullmatch(cleaned):
+        raise SpecError(f"{field} contains unsupported characters")
+    return cleaned
+
+
+def _string_list(
+    value: Any,
+    field: str,
+    *,
+    minimum: int = 0,
+    maximum: int = 100,
+    item_maximum: int = 2000,
+) -> list[str]:
+    if not isinstance(value, list):
+        raise SpecError(f"{field} must be an array")
+    if not minimum <= len(value) <= maximum:
+        raise SpecError(f"{field} must contain {minimum} to {maximum} items")
+    result = [_nonempty(item, f"{field}[{index}]", item_maximum) for index, item in enumerate(value)]
+    if len(set(result)) != len(result):
+        raise SpecError(f"{field} contains duplicates")
+    return result
+
+
+def _id_list(
+    value: Any, field: str, *, minimum: int = 0, maximum: int = 100
+) -> list[str]:
+    result = _string_list(value, field, minimum=minimum, maximum=maximum, item_maximum=128)
+    for item in result:
+        if not ID_RE.fullmatch(item):
+            raise SpecError(f"{field} contains an invalid ID: {item}")
+    return result
+
+
+def _security_normalize(value: str) -> str:
+    normalized = unicodedata.normalize("NFKC", value)
+    return "".join(
+        character
+        for character in normalized
+        if unicodedata.category(character) != "Cf"
+    )
+
+
+def _normalize_text(value: str) -> str:
+    return " ".join(value.casefold().split())
+
+
+def _normalize_security_text(value: str) -> str:
+    return " ".join(_security_normalize(value).casefold().split())
+
+
+def _normalize_choice_surface(value: str) -> str:
+    return re.sub(
+        r"[\W_]+", "", _security_normalize(value).casefold(), flags=re.UNICODE
+    )
+
+
+def _normalize_phrase(value: str) -> str:
+    return " ".join(
+        part
+        for part in re.split(
+            r"[^\w]+", _security_normalize(value).casefold(), flags=re.UNICODE
+        )
+        if part
+    )
+
+
+def choice_description_leaks_answer(value: Any) -> bool:
+    """Return True when visible option copy evaluates its own correctness."""
+
+    if not isinstance(value, str) or not value.strip():
+        return False
+    normalized = _normalize_security_text(value)
+    return any(pattern.search(normalized) for pattern in ANSWER_REVEAL_PATTERNS)
+
+
+def _choice_description_has_boundary(value: str) -> bool:
+    return BOUNDARY_SIGNAL_PATTERN.search(_normalize_security_text(value)) is not None
+
+
+def choice_description_is_safe(label: Any, description: Any) -> bool:
+    """Return True for present, non-repeated copy without correctness cues."""
+
+    if not isinstance(label, str) or not label.strip():
+        return False
+    if not isinstance(description, str) or not description.strip():
+        return False
+    return (
+        len(_normalize_choice_surface(description)) >= 4
+        and _normalize_choice_surface(label) != _normalize_choice_surface(description)
+        and not choice_description_leaks_answer(description)
+        and _choice_description_has_boundary(description)
+    )
+
+
+def _question_surface_leaks_answer(value: str, question: Mapping[str, Any]) -> bool:
+    """Detect pre-commit copy that points at the current scored choice."""
+
+    normalized = _normalize_security_text(value)
+    if any(pattern.search(normalized) for pattern in QUESTION_ANSWER_REVEAL_PATTERNS):
+        return True
+
+    correct_option_id = question.get("correct_option_id")
+    correct_label = next(
+        (
+            option.get("label", "")
+            for option in question.get("options", [])
+            if option.get("id") == correct_option_id
+        ),
+        "",
+    )
+    if not isinstance(correct_label, str) or not correct_label.strip():
+        return False
+    visible_surface = _normalize_choice_surface(value)
+    correct_surface = _normalize_choice_surface(correct_label)
+    if visible_surface == correct_surface:
+        return True
+    meaningful_label = (
+        len(correct_surface) >= 5
+        or bool(re.search(r"[\u3400-\u9fff]", correct_label))
+        and len(correct_surface) >= 4
+    )
+    if meaningful_label and _contains_hidden_choice_surface(value, [correct_label]):
+        return True
+    if not _contains_hidden_choice_surface(value, [correct_label]):
+        return False
+    return bool(
+        re.search(
+            r"\b(?:select|choose|pick|adopt)\b|"
+            r"\b(?:correct|right|best|preferred|recommended)\s+"
+            r"(?:answer|option|choice|response|approach)\b|"
+            r"(?:選擇|選取|採用|正確答案|正解|最佳選項|首選)",
+            normalized,
+            re.IGNORECASE,
+        )
+    )
+
+
+def _contains_stable_choice_token(
+    value: str,
+    tokens: Iterable[str],
+    *,
+    strict_tokens: Iterable[str] = (),
+) -> str | None:
+    folded = _security_normalize(value).casefold()
+    strict = {_security_normalize(token).casefold() for token in strict_tokens}
+    for token in tokens:
+        normalized_token = _security_normalize(token).casefold()
+        if len(normalized_token) <= 3 and normalized_token.isalpha():
+            token_pattern = (
+                rf"(?<![a-z0-9]){re.escape(normalized_token)}(?![a-z0-9])"
+            )
+            strong_context = (
+                r"(?:\b(?:internal|identifier|id|key|token)\b|"
+                r"(?:內部|識別碼|代碼))"
+            )
+            entity_context = (
+                r"(?:\b(?:option|choice|answer|question|kernel|concept|scenario|tag)\b|"
+                r"(?:選項|答案|題目|核心|概念|情境|標籤))"
+            )
+            relation_context = (
+                r"(?:\s*(?:is|means|denotes|identifies|maps\s+to|=|:)\s*|"
+                r".{0,4}(?:是|為|代表|對應).{0,4})"
+            )
+            if (
+                normalized_token in strict
+                and normalized_token not in SHORT_STABLE_TOKEN_STOPWORDS
+            ):
+                matched = re.search(token_pattern, folded) is not None
+            else:
+                matched = (
+                    re.search(rf"{strong_context}.{{0,20}}{token_pattern}", folded)
+                    is not None
+                    or re.search(
+                        rf"{token_pattern}{relation_context}.{{0,16}}{strong_context}",
+                        folded,
+                    )
+                    is not None
+                    or re.search(
+                        rf"{entity_context}\s*[:=#-]?\s*{token_pattern}", folded
+                    )
+                    is not None
+                    or re.search(
+                        rf"{token_pattern}{relation_context}.{{0,16}}{entity_context}",
+                        folded,
+                    )
+                    is not None
+                )
+        else:
+            token_pattern = (
+                rf"(?<![a-z0-9]){re.escape(normalized_token)}(?![a-z0-9])"
+            )
+            matched = re.search(token_pattern, folded) is not None
+        if matched:
+            return token
+    return None
+
+
+def _contains_hidden_choice_surface(value: str, hidden_values: Iterable[str]) -> bool:
+    visible_phrase = _normalize_phrase(value)
+    visible_compact = _normalize_choice_surface(value)
+    for hidden_value in hidden_values:
+        hidden_phrase = _normalize_phrase(hidden_value)
+        if not hidden_phrase:
+            continue
+        if re.search(r"[\u3400-\u9fff]", hidden_phrase):
+            hidden_compact = _normalize_choice_surface(hidden_value)
+            matched = hidden_compact in visible_compact
+        else:
+            matched = f" {hidden_phrase} " in f" {visible_phrase} "
+        if matched:
+            return True
+    return False
+
+
+def validate_visible_context_contract(
+    spec: Mapping[str, Any],
+    visible_entries: Iterable[tuple[str, Any]],
+    *,
+    allow_plain_option_labels: bool = False,
+) -> None:
+    """Reject answer material embedded in phase-level visible context."""
+
+    phase = spec.get("phase")
+    if phase in {"assessment", "review"}:
+        questions = list(spec.get("questions", []))
+    elif phase == "learning":
+        questions = [
+            area.get("checkpoint", {}) for area in spec.get("areas", [])
+        ]
+    else:
+        raise SpecError("Visible context validation requires a v3 phase spec")
+
+    stable_tokens: set[str] = set()
+    strict_tokens: set[str] = set()
+    always_hidden_surfaces: list[str] = []
+    plain_topic_surfaces: list[str] = []
+    correct_label_surfaces: list[str] = []
+    for question in questions:
+        for field in (
+            "question_id",
+            "concept_id",
+            "knowledge_kernel_id",
+            "primary_kernel_id",
+            "scenario_id",
+            "source_question_id",
+            "correct_option_id",
+        ):
+            value = question.get(field)
+            if isinstance(value, str) and value:
+                stable_tokens.add(value)
+                if field == "correct_option_id":
+                    strict_tokens.add(value)
+        integrated = question.get("integrated_kernel_ids", [])
+        if isinstance(integrated, list):
+            stable_tokens.update(
+                value for value in integrated if isinstance(value, str)
+            )
+        lineage = question.get("lineage", {})
+        if isinstance(lineage, Mapping):
+            for values in lineage.values():
+                if isinstance(values, list):
+                    stable_tokens.update(
+                        value for value in values if isinstance(value, str)
+                    )
+        always_hidden_surfaces.extend(
+            question.get(field, "")
+            for field in (
+                "scenario_context",
+                "prompt",
+                "core_proposition",
+            )
+        )
+        plain_topic_surfaces.append(question.get("title", ""))
+        for option in question.get("options", []):
+            option_id = option.get("id")
+            if isinstance(option_id, str) and option_id:
+                stable_tokens.add(option_id)
+                strict_tokens.add(option_id)
+            misconception_tag = option.get("misconception_tag")
+            if isinstance(misconception_tag, str) and misconception_tag:
+                stable_tokens.add(misconception_tag)
+                strict_tokens.add(misconception_tag)
+            option_label = option.get("label", "")
+            if option.get("id") == question.get("correct_option_id"):
+                correct_label_surfaces.append(option_label)
+            else:
+                plain_topic_surfaces.append(option_label)
+            always_hidden_surfaces.extend(
+                option.get(field, "")
+                for field in ("description", "explanation")
+            )
+
+    for field, raw_value in visible_entries:
+        value = _nonempty(raw_value, field, 4000)
+        if _contains_stable_choice_token(
+            value, stable_tokens, strict_tokens=strict_tokens
+        ) is not None:
+            raise SpecError(f"{field} exposes a stable internal token")
+        normalized = _normalize_security_text(value)
+        if any(
+            pattern.search(normalized)
+            for pattern in QUESTION_ANSWER_REVEAL_PATTERNS
+        ):
+            raise SpecError(f"{field} reveals correctness or points to an answer")
+        if _contains_hidden_choice_surface(value, always_hidden_surfaces):
+            raise SpecError(f"{field} exposes hidden or future question content")
+        exposes_plain_surface = _contains_hidden_choice_surface(
+            value, plain_topic_surfaces
+        )
+        exposes_correct_label = _contains_hidden_choice_surface(
+            value, correct_label_surfaces
+        )
+        value_surface = _normalize_choice_surface(value)
+        equals_correct_label = any(
+            value_surface == _normalize_choice_surface(label)
+            for label in correct_label_surfaces
+            if isinstance(label, str) and label.strip()
+        )
+        has_answer_cue = VISIBLE_CONTEXT_ANSWER_CUE_PATTERN.search(normalized)
+        exposes_answer_like_label = any(
+            ANSWER_LIKE_LABEL_PATTERN.search(_normalize_security_text(label))
+            and _contains_hidden_choice_surface(value, [label])
+            for label in correct_label_surfaces
+        )
+        if equals_correct_label or (
+            exposes_correct_label and (has_answer_cue or exposes_answer_like_label)
+        ):
+            raise SpecError(f"{field} exposes hidden or future question content")
+        if exposes_plain_surface and (
+            not allow_plain_option_labels
+            or has_answer_cue
+        ):
+            raise SpecError(f"{field} exposes hidden or future question content")
+        if has_answer_cue and any(
+            _question_surface_leaks_answer(value, question)
+            for question in questions
+        ):
+            raise SpecError(f"{field} reveals correctness or points to an answer")
+
+
+def scenario_fingerprint(value: str) -> str:
+    """Return a stable semantic-surface fingerprint for scenario reuse checks."""
+
+    normalized = _normalize_text(_nonempty(value, "scenario_context", 4000))
+    return hashlib.sha256(normalized.encode("utf-8")).hexdigest()
+
+
+def _content_digest(value: Mapping[str, Any]) -> str:
+    encoded = json.dumps(
+        value, ensure_ascii=False, sort_keys=True, separators=(",", ":")
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _cycle_contract_digest(cycle: Mapping[str, Any]) -> str:
+    """Bind evidence to the confirmed mission, scope, and area semantics."""
+
+    return _content_digest(
+        {
+            "schema_version": cycle["schema_version"],
+            "cycle_id": cycle["cycle_id"],
+            "mission": cycle["mission"],
+            "knowledge_scope": cycle["knowledge_scope"],
+            "areas": cycle["areas"],
+        }
+    )
+
+
+def _question_digest(question: Mapping[str, Any]) -> str:
+    """Bind an evidence record to the exact normalized server-side question."""
+
+    return _content_digest(question)
+
+
+def _slice_digest(item: Mapping[str, Any]) -> str:
+    """Bind completion evidence to the exact normalized Learning Slice."""
+
+    return _content_digest(item)
+
+
+def _near_duplicate(left: str, right: str, *, threshold: float = 0.84) -> bool:
+    """Detect trivial scenario rewrites in addition to exact fingerprints.
+
+    This intentionally stays conservative and deterministic. Generators remain
+    responsible for semantic novelty that lexical similarity cannot detect.
+    """
+
+    return (
+        difflib.SequenceMatcher(
+            None, _normalize_text(left), _normalize_text(right), autojunk=False
+        ).ratio()
+        >= threshold
+    )
+
+
+def clamp(value: int, minimum: int, maximum: int) -> int:
+    return max(minimum, min(value, maximum))
+
+
+def resolve_within(root: Path, candidate: Path) -> Path:
+    try:
+        root = Path(root).resolve()
+        resolved = Path(candidate).resolve()
+    except (OSError, RuntimeError) as exc:
+        raise SpecError(f"Unable to resolve contained path: {candidate}") from exc
+    try:
+        resolved.relative_to(root)
+    except ValueError as exc:
+        raise SpecError(f"Path must stay inside workspace: {resolved}") from exc
+    return resolved
+
+
+def _contained_child(root: Path, *parts: str) -> Path:
+    """Resolve a mutable child while following existing links safely."""
+
+    raw_root = Path(root)
+    return resolve_within(raw_root, raw_root.joinpath(*parts))
+
+
+def _require_regular_or_absent(root: Path, relative: str, label: str) -> Path:
+    raw = Path(root) / relative
+    if raw.is_symlink():
+        raise SpecError(f"{label} cannot be a symbolic link: {raw}")
+    path = _contained_child(root, relative)
+    if path.exists() and not path.is_file():
+        raise SpecError(f"{label} must be a regular file or absent: {path}")
+    return path
+
+
+def _require_directory_or_absent(root: Path, relative: str, label: str) -> Path:
+    raw = Path(root) / relative
+    if raw.is_symlink():
+        raise SpecError(f"{label} cannot be a symbolic link: {raw}")
+    path = _contained_child(root, relative)
+    if path.exists() and not path.is_dir():
+        raise SpecError(f"{label} must be a directory or absent: {path}")
+    return path
+
+
+def validate_phase_write_surface(
+    cycle_dir: Path, phase_dir: Path, phase: str
+) -> dict[str, Path]:
+    """Preflight every reserved mutable target before a server says ready."""
+
+    if phase not in PHASES:
+        raise SpecError(f"Unknown phase: {phase}")
+    cycle_root = resolve_within(cycle_dir, cycle_dir)
+    phase_root = resolve_within(cycle_root, phase_dir)
+    if not phase_root.is_dir():
+        raise SpecError(f"Phase directory not found: {phase_root}")
+
+    result = {
+        "checkpoint": _require_regular_or_absent(
+            cycle_root, "checkpoint.json", "Checkpoint path"
+        ),
+        "lock": _require_regular_or_absent(
+            cycle_root, ".cycle.lock", "Cycle lock path"
+        ),
+        "report": _require_regular_or_absent(
+            phase_root, "report.json", "Phase report path"
+        ),
+    }
+    if phase in {"assessment", "review"}:
+        result["manifest"] = _require_regular_or_absent(
+            phase_root, "batch-manifest.json", "Batch manifest path"
+        )
+        result["evidence_dir"] = _require_directory_or_absent(
+            phase_root, "responses", "Responses path"
+        )
+    else:
+        result["evidence_dir"] = _require_directory_or_absent(
+            phase_root, "events", "Learning events path"
+        )
+    return result
+
+
+def read_json_object(path: Path) -> dict[str, Any]:
+    try:
+        data = json.loads(Path(path).read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+        raise SpecError(f"Invalid JSON object at {path}: {exc}") from exc
+    if not isinstance(data, dict):
+        raise SpecError(f"Expected a JSON object at {path}")
+    return data
+
+
+def _encoded_json(payload: Mapping[str, Any]) -> bytes:
+    return (json.dumps(payload, ensure_ascii=False, indent=2) + "\n").encode("utf-8")
+
+
+def _fsync_parent(path: Path) -> None:
+    """Best-effort directory sync; Windows may reject directory descriptors."""
+
+    try:
+        descriptor = os.open(path.parent, os.O_RDONLY)
+    except OSError:
+        return
+    try:
+        os.fsync(descriptor)
+    except OSError:
+        pass
+    finally:
+        os.close(descriptor)
+
+
+def atomic_write_json(path: Path, payload: Mapping[str, Any]) -> None:
+    """Atomically publish JSON through a same-directory, flushed temp file."""
+
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    descriptor, temporary_name = tempfile.mkstemp(
+        prefix=f".{path.name}.", suffix=".tmp", dir=path.parent
+    )
+    temporary = Path(temporary_name)
+    try:
+        with os.fdopen(descriptor, "wb") as handle:
+            handle.write(_encoded_json(payload))
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temporary, path)
+        _fsync_parent(path)
+    except Exception:
+        temporary.unlink(missing_ok=True)
+        raise
+
+
+def write_json_once(path: Path, payload: Mapping[str, Any]) -> None:
+    """Atomically publish flushed JSON without ever overwriting evidence."""
+
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    descriptor, temporary_name = tempfile.mkstemp(
+        prefix=f".{path.name}.", suffix=".tmp", dir=path.parent
+    )
+    temporary = Path(temporary_name)
+    try:
+        with os.fdopen(descriptor, "wb") as handle:
+            handle.write(_encoded_json(payload))
+            handle.flush()
+            os.fsync(handle.fileno())
+        # A same-directory hard-link publish is atomic and refuses an existing
+        # destination on both Windows and POSIX. A crash can leave only a
+        # complete temp file or a complete final record, never a partial final.
+        os.link(temporary, path)
+        _fsync_parent(path)
+    finally:
+        temporary.unlink(missing_ok=True)
+
+
+class PhaseLock:
+    """Cycle-wide OS lock that the operating system releases after a crash."""
+
+    def __init__(self, cycle_dir: Path, phase: str):
+        if phase not in PHASES:
+            raise SpecError(f"Unknown phase: {phase}")
+        self.phase = phase
+        cycle_root = resolve_within(cycle_dir, cycle_dir)
+        raw_path = Path(cycle_dir) / ".cycle.lock"
+        if raw_path.is_symlink():
+            raise ConflictError(f"Cycle lock cannot be a symbolic link: {raw_path}")
+        self.path = resolve_within(cycle_root, raw_path)
+        if self.path.exists() and not self.path.is_file():
+            raise ConflictError(f"Cycle lock path is not a file: {self.path}")
+        self.token = secrets.token_urlsafe(24)
+        self._owned = False
+        self._handle: Any = None
+
+    @staticmethod
+    def _lock(handle: Any) -> None:
+        handle.seek(0)
+        if os.name == "nt":
+            import msvcrt
+
+            msvcrt.locking(handle.fileno(), msvcrt.LK_NBLCK, 1)
+            return
+        import fcntl
+
+        fcntl.flock(handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+
+    @staticmethod
+    def _unlock(handle: Any) -> None:
+        handle.seek(0)
+        if os.name == "nt":
+            import msvcrt
+
+            msvcrt.locking(handle.fileno(), msvcrt.LK_UNLCK, 1)
+            return
+        import fcntl
+
+        fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+
+    @staticmethod
+    def _write_lock_state(handle: Any, payload: Mapping[str, Any]) -> None:
+        handle.seek(0)
+        handle.truncate()
+        handle.write(_encoded_json(payload))
+        handle.flush()
+        os.fsync(handle.fileno())
+
+    def __enter__(self) -> "PhaseLock":
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        try:
+            handle = self.path.open("a+b")
+        except OSError as exc:
+            raise ConflictError(f"Phase is already locked: {self.path}") from exc
+        if self.path.stat().st_size == 0:
+            handle.write(b"\0")
+            handle.flush()
+        try:
+            self._lock(handle)
+        except OSError as exc:
+            handle.close()
+            raise ConflictError(f"Phase is already locked: {self.path}") from exc
+        payload = {
+            "schema_version": 3,
+            "phase": self.phase,
+            "token": self.token,
+            "pid": os.getpid(),
+            "acquired_at": utc_now(),
+            "active": True,
+        }
+        try:
+            self._write_lock_state(handle, payload)
+        except Exception:
+            self._unlock(handle)
+            handle.close()
+            raise
+        self._handle = handle
+        self._owned = True
+        return self
+
+    def __exit__(self, exc_type: Any, exc: Any, traceback: Any) -> None:
+        if not self._owned:
+            return
+        handle = self._handle
+        if handle is None:
+            return
+        try:
+            self._write_lock_state(
+                handle,
+                {
+                    "schema_version": 3,
+                    "phase": self.phase,
+                    "token": self.token,
+                    "pid": os.getpid(),
+                    "active": False,
+                    "released_at": utc_now(),
+                },
+            )
+        finally:
+            try:
+                self._unlock(handle)
+            finally:
+                handle.close()
+                self._handle = None
+                self._owned = False
+
+
+def validate_cycle(data: Mapping[str, Any]) -> dict[str, Any]:
+    if not isinstance(data, Mapping):
+        raise SpecError("cycle must be an object")
+    if data.get("schema_version") != 3:
+        raise SpecError("cycle schema_version must be 3")
+    cycle_id = _identifier(data.get("cycle_id"), "cycle_id")
+
+    mission = data.get("mission")
+    if not isinstance(mission, Mapping):
+        raise SpecError("mission must be an object")
+    intent_id = _identifier(mission.get("intent_id"), "mission.intent_id")
+    if intent_id not in GOAL_INTENTS:
+        raise SpecError(f"mission.intent_id must be one of: {sorted(GOAL_INTENTS)}")
+    normalized_mission = {
+        "intent_id": intent_id,
+        "ultimate_outcome": _nonempty(
+            mission.get("ultimate_outcome"), "mission.ultimate_outcome", 2000
+        ),
+        "audience": _optional(mission.get("audience"), "mission.audience", 240),
+    }
+
+    scope = data.get("knowledge_scope")
+    if not isinstance(scope, Mapping):
+        raise SpecError("knowledge_scope must be an object")
+    status = scope.get("benchmark_status")
+    if status not in BENCHMARK_STATUSES:
+        raise SpecError(
+            "knowledge_scope.benchmark_status must be verified, partially_verified, or provisional"
+        )
+    sources = _string_list(scope.get("sources", []), "knowledge_scope.sources", maximum=100)
+    if status == "verified" and not sources:
+        raise SpecError("verified knowledge_scope requires at least one source")
+    normalized_scope = {
+        "title": _nonempty(scope.get("title"), "knowledge_scope.title", 240),
+        "direction": _nonempty(scope.get("direction"), "knowledge_scope.direction", 2000),
+        "includes": _string_list(
+            scope.get("includes"), "knowledge_scope.includes", minimum=1, maximum=50
+        ),
+        "excludes": _string_list(
+            scope.get("excludes"), "knowledge_scope.excludes", maximum=50
+        ),
+        "benchmark_status": status,
+        "sources": sources,
+    }
+
+    areas = data.get("areas")
+    if not isinstance(areas, list) or not 3 <= len(areas) <= 6:
+        raise SpecError("cycle.areas must contain 3 to 6 areas")
+    normalized_areas: list[dict[str, Any]] = []
+    area_ids: set[str] = set()
+    for index, area in enumerate(areas):
+        if not isinstance(area, Mapping):
+            raise SpecError(f"areas[{index}] must be an object")
+        area_id = _identifier(area.get("area_id"), f"areas[{index}].area_id")
+        if area_id in area_ids:
+            raise SpecError(f"Duplicate area_id: {area_id}")
+        area_ids.add(area_id)
+        normalized_areas.append(
+            {
+                "area_id": area_id,
+                "title": _nonempty(area.get("title"), f"areas[{index}].title", 240),
+                "description": _nonempty(
+                    area.get("description"), f"areas[{index}].description", 1200
+                ),
+                "weight": _bounded_number(area.get("weight", 1), f"areas[{index}].weight", 0, 10),
+                "failure_cost": _bounded_number(
+                    area.get("failure_cost", 1), f"areas[{index}].failure_cost", 0, 10
+                ),
+                "uncertainty": _bounded_number(
+                    area.get("uncertainty", 1), f"areas[{index}].uncertainty", 0, 10
+                ),
+            }
+        )
+
+    artifacts = data.get("artifacts", {})
+    if not isinstance(artifacts, Mapping):
+        raise SpecError("artifacts must be an object")
+    unknown_artifacts = sorted(set(artifacts) - set(V3_ARTIFACT_PATHS))
+    if unknown_artifacts:
+        raise SpecError(f"Unsupported version 3 artifact keys: {unknown_artifacts}")
+    normalized_artifacts: dict[str, str] = dict(V3_ARTIFACT_PATHS)
+    for key, value in artifacts.items():
+        safe_key = _identifier(key, f"artifacts.{key}")
+        normalized_value = _nonempty(value, f"artifacts.{key}", 500)
+        if normalized_value != V3_ARTIFACT_PATHS[safe_key]:
+            raise SpecError(
+                f"Version 3 artifact {safe_key} must be {V3_ARTIFACT_PATHS[safe_key]}"
+            )
+
+    return {
+        "schema_version": 3,
+        "cycle_id": cycle_id,
+        "mission": normalized_mission,
+        "knowledge_scope": normalized_scope,
+        "areas": normalized_areas,
+        "artifacts": normalized_artifacts,
+    }
+
+
+def _bounded_number(value: Any, field: str, minimum: float, maximum: float) -> float:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise SpecError(f"{field} must be a number")
+    number = float(value)
+    if not minimum <= number <= maximum:
+        raise SpecError(f"{field} must be between {minimum} and {maximum}")
+    return number
+
+
+def resolve_cycle(workspace: Path, cycle_ref: str | Path) -> Path:
+    workspace = Path(workspace).resolve()
+    candidate = Path(cycle_ref)
+    if not candidate.is_absolute():
+        candidate = workspace / candidate
+    cycle_dir = resolve_within(workspace, candidate)
+    if not cycle_dir.is_dir():
+        raise SpecError(f"Cycle directory not found: {cycle_dir}")
+    return cycle_dir
+
+
+def load_cycle(workspace: Path, cycle_ref: str | Path) -> tuple[Path, dict[str, Any]]:
+    cycle_dir = resolve_cycle(workspace, cycle_ref)
+    cycle_path = cycle_dir / "cycle.json"
+    if not cycle_path.is_file():
+        raise SpecError(f"cycle.json not found: {cycle_path}")
+    return cycle_dir, validate_cycle(read_json_object(cycle_path))
+
+
+def _validate_option(option: Any, field: str) -> dict[str, str]:
+    if not isinstance(option, Mapping):
+        raise SpecError(f"{field} must be an object")
+    return {
+        "id": _identifier(option.get("id"), f"{field}.id"),
+        "label": _nonempty(option.get("label"), f"{field}.label", 300),
+        "description": _optional(option.get("description"), f"{field}.description", 800),
+        "explanation": _nonempty(option.get("explanation"), f"{field}.explanation", 2400),
+        "misconception_tag": _optional(
+            option.get("misconception_tag"), f"{field}.misconception_tag", 160
+        ),
+    }
+
+
+def validate_choice_description_contract(
+    spec: Mapping[str, Any], *, check_descriptions: bool = True,
+    check_future_surfaces: bool = True
+) -> None:
+    """Require neutral, informative pre-commit option subdescriptions.
+
+    This gate runs before a new batch or Learning contract is sealed. Existing
+    sealed v3 evidence can still resume; the UI suppresses an unsafe legacy
+    description set rather than changing immutable question content.
+    """
+
+    phase = spec.get("phase")
+    if phase in {"assessment", "review"}:
+        question_entries = [
+            (f"questions[{index}]", question)
+            for index, question in enumerate(spec.get("questions", []))
+        ]
+    elif phase == "learning":
+        question_entries = [
+            (f"areas[{index}].checkpoint", area.get("checkpoint", {}))
+            for index, area in enumerate(spec.get("areas", []))
+        ]
+    else:
+        raise SpecError("Choice description validation requires a v3 phase spec")
+
+    stable_tokens: set[str] = set()
+    strict_tokens: set[str] = set()
+    for _, question in question_entries:
+        for field in (
+            "question_id",
+            "concept_id",
+            "knowledge_kernel_id",
+            "primary_kernel_id",
+            "scenario_id",
+            "source_question_id",
+            "correct_option_id",
+        ):
+            value = question.get(field)
+            if isinstance(value, str) and value:
+                stable_tokens.add(value)
+                if field == "correct_option_id":
+                    strict_tokens.add(value)
+        for field in ("integrated_kernel_ids",):
+            values = question.get(field, [])
+            if isinstance(values, list):
+                stable_tokens.update(value for value in values if isinstance(value, str))
+        lineage = question.get("lineage", {})
+        if isinstance(lineage, Mapping):
+            for values in lineage.values():
+                if isinstance(values, list):
+                    stable_tokens.update(
+                        value for value in values if isinstance(value, str)
+                    )
+        for option in question.get("options", []):
+            option_id = option.get("id")
+            if isinstance(option_id, str) and option_id:
+                stable_tokens.add(option_id)
+                strict_tokens.add(option_id)
+            misconception_tag = option.get("misconception_tag")
+            if isinstance(misconception_tag, str) and misconception_tag:
+                stable_tokens.add(misconception_tag)
+                strict_tokens.add(misconception_tag)
+
+    question_surface_counts = {
+        field: Counter(
+            _normalize_choice_surface(str(question.get(field, "")))
+            for _, question in question_entries
+            if question.get(field)
+        )
+        for field in ("title", "scenario_context", "prompt")
+    }
+    intro_entries: list[tuple[str, str]] = []
+    for field in ("title", "instructions"):
+        value = spec.get(field)
+        if isinstance(value, str) and value.strip():
+            intro_entries.append((field, value))
+    if phase == "learning":
+        intro_entries.extend(
+            (f"areas[{index}].title", str(area.get("title", "")))
+            for index, area in enumerate(spec.get("areas", []))
+            if area.get("title")
+        )
+    intro_hidden_surfaces = [
+        surface
+        for _, question in question_entries
+        for surface in [
+            question.get("title", ""),
+            question.get("scenario_context", ""),
+            question.get("prompt", ""),
+            question.get("core_proposition", ""),
+            *(
+                option.get(field, "")
+                for option in question.get("options", [])
+                for field in ("label", "description", "explanation")
+            ),
+        ]
+    ]
+    for field, value in intro_entries:
+        leaked_token = _contains_stable_choice_token(
+            value, stable_tokens, strict_tokens=strict_tokens
+        )
+        if leaked_token is not None:
+            raise SpecError(f"{field} exposes a stable internal token")
+        if _contains_hidden_choice_surface(value, intro_hidden_surfaces):
+            raise SpecError(f"{field} exposes hidden or future question content")
+        if any(
+            _question_surface_leaks_answer(value, question)
+            for _, question in question_entries
+        ):
+            raise SpecError(f"{field} reveals correctness or points to an answer")
+
+    for question_index, (question_field, question) in enumerate(question_entries):
+        current_hidden_surfaces = [
+            question.get("core_proposition", ""),
+            *(
+                option.get("explanation", "")
+                for option in question.get("options", [])
+            ),
+        ]
+        current_question_hidden_surfaces = [
+            *current_hidden_surfaces,
+            *(
+                option.get(field, "")
+                for option in question.get("options", [])
+                for field in ("label", "description")
+            ),
+        ]
+        future_question_surfaces: list[str] = []
+        future_question_surfaces_by_field: dict[str, list[str]] = {
+            "title": [],
+            "scenario_context": [],
+            "prompt": [],
+        }
+        future_core_surfaces: list[str] = []
+        future_option_surfaces: list[str] = []
+        future_option_labels: list[str] = []
+        future_option_support_surfaces: list[str] = []
+        future_correct_surfaces: list[str] = []
+        for _, future_question in question_entries[question_index + 1 :]:
+            future_question_surfaces.extend(
+                future_question.get(field, "")
+                for field in (
+                    "title",
+                    "scenario_context",
+                    "prompt",
+                    "core_proposition",
+                )
+            )
+            for field in future_question_surfaces_by_field:
+                future_question_surfaces_by_field[field].append(
+                    future_question.get(field, "")
+                )
+            future_core_surfaces.append(
+                future_question.get("core_proposition", "")
+            )
+            for future_option in future_question.get("options", []):
+                option_surfaces = [
+                    future_option.get(field, "")
+                    for field in ("label", "description", "explanation")
+                ]
+                future_option_surfaces.extend(option_surfaces)
+                future_option_labels.append(option_surfaces[0])
+                future_option_support_surfaces.extend(option_surfaces[1:])
+                if future_option.get("id") == future_question.get(
+                    "correct_option_id"
+                ):
+                    future_correct_surfaces.extend(option_surfaces)
+        if check_future_surfaces:
+            question_hidden_surfaces = [
+                *current_question_hidden_surfaces,
+                *future_question_surfaces,
+                *future_option_surfaces,
+            ]
+            option_hidden_surfaces = [
+                *current_hidden_surfaces,
+                *future_question_surfaces,
+                *future_option_surfaces,
+            ]
+        else:
+            question_hidden_surfaces = [
+                *current_hidden_surfaces,
+                *future_question_surfaces,
+                *future_option_labels,
+                *future_option_support_surfaces,
+                *future_correct_surfaces,
+            ]
+            option_hidden_surfaces = [
+                *current_hidden_surfaces,
+                *future_question_surfaces,
+                *future_option_labels,
+                *future_option_support_surfaces,
+                *future_correct_surfaces,
+            ]
+
+        for surface_field in ("title", "scenario_context", "prompt"):
+            value = _nonempty(
+                question.get(surface_field), f"{question_field}.{surface_field}", 4000
+            )
+            if _question_surface_leaks_answer(value, question):
+                raise SpecError(
+                    f"{question_field}.{surface_field} reveals correctness or points to the correct answer"
+                )
+            leaked_token = _contains_stable_choice_token(
+                value, stable_tokens, strict_tokens=strict_tokens
+            )
+            if leaked_token is not None:
+                raise SpecError(
+                    f"{question_field}.{surface_field} exposes a stable internal token"
+                )
+            if check_future_surfaces:
+                hidden_surfaces = question_hidden_surfaces
+            else:
+                hidden_surfaces = [
+                    *current_question_hidden_surfaces,
+                    *future_core_surfaces,
+                    *future_option_labels,
+                    *future_option_support_surfaces,
+                    *future_correct_surfaces,
+                ]
+                normalized_value = _normalize_choice_surface(value)
+                repeated_template = (
+                    question_surface_counts[surface_field][normalized_value] >= 3
+                )
+                for future_field, future_values in (
+                    future_question_surfaces_by_field.items()
+                ):
+                    for future_value in future_values:
+                        if (
+                            repeated_template
+                            and future_field == surface_field
+                            and _normalize_choice_surface(future_value)
+                            == normalized_value
+                        ):
+                            continue
+                        hidden_surfaces.append(future_value)
+            if _contains_hidden_choice_surface(value, hidden_surfaces):
+                raise SpecError(
+                    f"{question_field}.{surface_field} exposes hidden or future question content"
+                )
+
+        for option_index, option in enumerate(question.get("options", [])):
+            field = f"{question_field}.options[{option_index}]"
+            label = _nonempty(option.get("label"), f"{field}.label", 300)
+            if choice_description_leaks_answer(label):
+                raise SpecError(
+                    f"{field}.label reveals correctness or recommends its own selection"
+                )
+            surfaces = [("label", label)]
+            if check_descriptions:
+                description = _nonempty(
+                    option.get("description"), f"{field}.description", 800
+                )
+                if len(_normalize_choice_surface(description)) < 4:
+                    raise SpecError(
+                        f"{field}.description must contain meaningful boundary text"
+                    )
+                normalized_label = _normalize_choice_surface(label)
+                contains_label = _contains_hidden_choice_surface(
+                    description, [label]
+                )
+                repeats_label = (
+                    _normalize_choice_surface(description) == normalized_label
+                    or len(normalized_label) >= 4
+                    and contains_label
+                    or contains_label
+                    and OWN_LABEL_CUE_PATTERN.search(
+                        _normalize_security_text(description)
+                    )
+                )
+                if repeats_label:
+                    raise SpecError(
+                        f"{field}.description must supplement rather than repeat its label"
+                    )
+                if not _choice_description_has_boundary(description):
+                    raise SpecError(
+                        f"{field}.description must add an explicit boundary, prerequisite, tradeoff, or omitted factor"
+                    )
+                if choice_description_leaks_answer(description):
+                    raise SpecError(
+                        f"{field}.description reveals correctness; describe only a boundary, prerequisite, tradeoff, or omitted factor"
+                    )
+                surfaces.append(("description", description))
+            for surface_field, value in surfaces:
+                leaked_token = _contains_stable_choice_token(
+                    value, stable_tokens, strict_tokens=strict_tokens
+                )
+                if leaked_token is not None:
+                    raise SpecError(
+                        f"{field}.{surface_field} exposes a stable internal token"
+                    )
+                hidden_surfaces = [
+                    *option_hidden_surfaces,
+                    *(
+                        other_option.get(other_field, "")
+                        for other_index, other_option in enumerate(
+                            question.get("options", [])
+                        )
+                        if other_index != option_index
+                        for other_field in ("label", "description")
+                    ),
+                ]
+                if _contains_hidden_choice_surface(value, hidden_surfaces):
+                    raise SpecError(
+                        f"{field}.{surface_field} exposes hidden or future question content"
+                    )
+
+
+def validate_choice_label_contract(
+    spec: Mapping[str, Any], *, check_future_surfaces: bool = True
+) -> None:
+    """Reject scored labels that disclose server-only answer material."""
+
+    validate_choice_description_contract(
+        spec,
+        check_descriptions=False,
+        check_future_surfaces=check_future_surfaces,
+    )
+
+
+def _validate_question(
+    question: Any,
+    field: str,
+    *,
+    phase: str,
+    area_ids: set[str],
+    review: bool = False,
+) -> dict[str, Any]:
+    if not isinstance(question, Mapping):
+        raise SpecError(f"{field} must be an object")
+    question_id = _identifier(question.get("question_id"), f"{field}.question_id")
+    area_id = _identifier(question.get("area_id"), f"{field}.area_id")
+    if area_id not in area_ids:
+        raise SpecError(f"{field}.area_id is not declared by the cycle: {area_id}")
+    family = question.get("question_family")
+    if family not in QUESTION_FAMILIES:
+        raise SpecError(f"{field}.question_family is unsupported")
+    options = question.get("options")
+    if not isinstance(options, list) or not 3 <= len(options) <= 5:
+        raise SpecError(f"{field}.options must contain 3 to 5 choices")
+    normalized_options = [
+        _validate_option(option, f"{field}.options[{index}]")
+        for index, option in enumerate(options)
+    ]
+    option_ids = [item["id"] for item in normalized_options]
+    if len(set(option_ids)) != len(option_ids):
+        raise SpecError(f"{field}.options contains duplicate IDs")
+    visible_labels = [_normalize_text(item["label"]) for item in normalized_options]
+    visible_surfaces = [
+        (_normalize_text(item["label"]), _normalize_text(item["description"]))
+        for item in normalized_options
+    ]
+    if len(set(visible_labels)) != len(visible_labels) or len(
+        set(visible_surfaces)
+    ) != len(visible_surfaces):
+        raise SpecError(f"{field}.options contains duplicate learner-visible choices")
+
+    correct_value = question.get("correct_option_id")
+    legacy_correct = question.get("correct_option_ids")
+    if legacy_correct is not None:
+        if not isinstance(legacy_correct, list) or len(legacy_correct) != 1:
+            raise SpecError(f"{field}.correct_option_ids must contain exactly one answer")
+        if correct_value not in (None, "") and legacy_correct[0] != correct_value:
+            raise SpecError(f"{field} has conflicting correct answer fields")
+        if correct_value in (None, ""):
+            correct_value = legacy_correct[0]
+    correct_id = _identifier(correct_value, f"{field}.correct_option_id")
+    if correct_id not in option_ids:
+        raise SpecError(f"{field}.correct_option_id is not an option")
+    for option in normalized_options:
+        if option["id"] != correct_id and not option["misconception_tag"]:
+            raise SpecError(
+                f"{field}.options wrong choices require misconception_tag"
+            )
+
+    scenario_context = _nonempty(
+        question.get("scenario_context"), f"{field}.scenario_context", 4000
+    )
+    normalized: dict[str, Any] = {
+        "question_id": question_id,
+        "area_id": area_id,
+        "concept_id": _identifier(question.get("concept_id"), f"{field}.concept_id"),
+        "core_proposition": _nonempty(
+            question.get("core_proposition"), f"{field}.core_proposition", 2400
+        ),
+        "scenario_id": _identifier(question.get("scenario_id"), f"{field}.scenario_id"),
+        "scenario_context": scenario_context,
+        "scenario_fingerprint": scenario_fingerprint(scenario_context),
+        "question_family": family,
+        "title": _nonempty(question.get("title"), f"{field}.title", 240),
+        "prompt": _nonempty(question.get("prompt"), f"{field}.prompt", 2400),
+        "sources": _string_list(
+            question.get("sources"), f"{field}.sources", minimum=1, maximum=50
+        ),
+        "options": normalized_options,
+        "correct_option_id": correct_id,
+        "correct_option_ids": [correct_id],
+        "importance": _bounded_number(
+            question.get("importance", 1), f"{field}.importance", 0, 10
+        ),
+    }
+    if review:
+        normalized["primary_kernel_id"] = _identifier(
+            question.get("primary_kernel_id"), f"{field}.primary_kernel_id"
+        )
+        normalized["knowledge_kernel_id"] = normalized["primary_kernel_id"]
+        normalized["integrated_kernel_ids"] = _id_list(
+            question.get("integrated_kernel_ids", []),
+            f"{field}.integrated_kernel_ids",
+            maximum=20,
+        )
+        if normalized["primary_kernel_id"] in normalized["integrated_kernel_ids"]:
+            raise SpecError(f"{field}.integrated_kernel_ids must not repeat the primary kernel")
+        normalized["source_question_id"] = _identifier(
+            question.get("source_question_id"), f"{field}.source_question_id"
+        )
+        lineage = question.get("lineage", {})
+        if not isinstance(lineage, Mapping):
+            raise SpecError(f"{field}.lineage must be an object")
+        normalized["lineage"] = {
+            "assessment_question_ids": _id_list(
+                lineage.get("assessment_question_ids", []),
+                f"{field}.lineage.assessment_question_ids",
+                maximum=20,
+            ),
+            "learning_slice_ids": _id_list(
+                lineage.get("learning_slice_ids", []),
+                f"{field}.lineage.learning_slice_ids",
+                maximum=50,
+            ),
+            "learning_checkpoint_ids": _id_list(
+                lineage.get("learning_checkpoint_ids", []),
+                f"{field}.lineage.learning_checkpoint_ids",
+                maximum=20,
+            ),
+        }
+    else:
+        normalized["knowledge_kernel_id"] = _identifier(
+            question.get("knowledge_kernel_id"), f"{field}.knowledge_kernel_id"
+        )
+    return normalized
+
+
+def _phase_header(data: Mapping[str, Any], phase: str) -> tuple[str, str]:
+    if data.get("schema_version") != 3:
+        raise SpecError(f"{phase} schema_version must be 3")
+    if data.get("phase") != phase:
+        raise SpecError(f"phase must be {phase}")
+    return (
+        _identifier(data.get("cycle_id"), "cycle_id"),
+        _nonempty(data.get("title"), "title", 240),
+    )
+
+
+def validate_assessment_spec(
+    data: Mapping[str, Any], cycle: Mapping[str, Any] | None = None
+) -> dict[str, Any]:
+    if not isinstance(data, Mapping):
+        raise SpecError("assessment spec must be an object")
+    cycle_id, title = _phase_header(data, "assessment")
+    normalized_cycle = validate_cycle(cycle) if cycle is not None else None
+    if normalized_cycle and cycle_id != normalized_cycle["cycle_id"]:
+        raise SpecError("assessment cycle_id does not match cycle.json")
+
+    if normalized_cycle:
+        area_ids = {area["area_id"] for area in normalized_cycle["areas"]}
+    else:
+        area_ids = set(_id_list(data.get("area_ids"), "area_ids", minimum=3, maximum=6))
+    questions = data.get("questions")
+    if not isinstance(questions, list) or not 10 <= len(questions) <= 20:
+        raise SpecError("assessment.questions must contain 10 to 20 questions")
+    normalized_questions = [
+        _validate_question(
+            question,
+            f"questions[{index}]",
+            phase="assessment",
+            area_ids=area_ids,
+        )
+        for index, question in enumerate(questions)
+    ]
+    _require_unique(normalized_questions, "question_id", "assessment question ID")
+    _require_unique(normalized_questions, "knowledge_kernel_id", "assessment knowledge kernel")
+    _require_unique(normalized_questions, "scenario_id", "assessment scenario ID")
+    _require_unique(
+        normalized_questions,
+        "scenario_fingerprint",
+        "assessment scenario fingerprint",
+    )
+
+    counts = {area_id: 0 for area_id in area_ids}
+    for question in normalized_questions:
+        counts[question["area_id"]] += 1
+    missing = [area_id for area_id, count in counts.items() if count < 2]
+    if missing:
+        raise SpecError(f"Every assessment area requires at least 2 questions: {missing}")
+
+    estimated = data.get("estimated_minutes")
+    if isinstance(estimated, bool) or not isinstance(estimated, int) or not 1 <= estimated <= 240:
+        raise SpecError("estimated_minutes must be an integer from 1 to 240")
+    result = {
+        "schema_version": 3,
+        "phase": "assessment",
+        "cycle_id": cycle_id,
+        "title": title,
+        "instructions": _nonempty(data.get("instructions"), "instructions", 2000),
+        "estimated_minutes": estimated,
+        "area_ids": sorted(area_ids),
+        "questions": normalized_questions,
+    }
+    if normalized_cycle is not None:
+        result["cycle_contract_digest"] = _cycle_contract_digest(normalized_cycle)
+    return result
+
+
+def _require_unique(items: Iterable[Mapping[str, Any]], key: str, label: str) -> None:
+    values = [str(item[key]) for item in items]
+    if len(set(values)) != len(values):
+        raise SpecError(f"Duplicate {label}")
+
+
+def validate_learning_slice(data: Mapping[str, Any], area_ids: set[str]) -> dict[str, Any]:
+    if not isinstance(data, Mapping):
+        raise SpecError("learning slice must be an object")
+    if data.get("schema_version") != 3:
+        raise SpecError("learning slice schema_version must be 3")
+    slice_id = _identifier(data.get("slice_id"), "slice_id")
+    area_id = _identifier(data.get("area_id"), "area_id")
+    if area_id not in area_ids:
+        raise SpecError(f"Slice area_id is not declared by the cycle: {area_id}")
+    order = data.get("order")
+    if isinstance(order, bool) or not isinstance(order, int) or order < 1:
+        raise SpecError("slice.order must be a positive integer")
+    difficulty = data.get("difficulty")
+    if difficulty not in DIFFICULTIES:
+        raise SpecError(f"slice.difficulty must be one of: {sorted(DIFFICULTIES)}")
+    example = data.get("worked_example")
+    if not isinstance(example, Mapping):
+        raise SpecError("worked_example must be an object")
+    example_context = _nonempty(
+        example.get("scenario_context"), "worked_example.scenario_context", 4000
+    )
+    return {
+        "schema_version": 3,
+        "slice_id": slice_id,
+        "area_id": area_id,
+        "title": _nonempty(data.get("title"), "slice.title", 240),
+        "order": order,
+        "difficulty": difficulty,
+        "prerequisites": _id_list(data.get("prerequisites", []), "slice.prerequisites", maximum=30),
+        "learning_objective": _nonempty(
+            data.get("learning_objective"), "slice.learning_objective", 1600
+        ),
+        "assessment_question_ids": _id_list(
+            data.get("assessment_question_ids", []),
+            "slice.assessment_question_ids",
+            minimum=1,
+            maximum=40,
+        ),
+        "addresses_gap_ids": _id_list(
+            data.get("addresses_gap_ids", []), "slice.addresses_gap_ids", maximum=40
+        ),
+        "core_explanation": _nonempty(
+            data.get("core_explanation"), "slice.core_explanation", 8000
+        ),
+        "mechanism": _nonempty(data.get("mechanism"), "slice.mechanism", 4000),
+        "boundaries": _string_list(
+            data.get("boundaries"), "slice.boundaries", minimum=1, maximum=30
+        ),
+        "worked_example": {
+            "scenario_id": _identifier(
+                example.get("scenario_id"), "worked_example.scenario_id"
+            ),
+            "scenario_context": example_context,
+            "scenario_fingerprint": scenario_fingerprint(example_context),
+            "walkthrough": _nonempty(
+                example.get("walkthrough"), "worked_example.walkthrough", 8000
+            ),
+        },
+        "common_mistakes": _string_list(
+            data.get("common_mistakes"), "slice.common_mistakes", minimum=1, maximum=30
+        ),
+        "key_takeaways": _string_list(
+            data.get("key_takeaways"), "slice.key_takeaways", minimum=1, maximum=30
+        ),
+        "sources": _string_list(data.get("sources"), "slice.sources", minimum=1, maximum=50),
+    }
+
+
+def _slice_mapping(
+    slices: Mapping[str, Mapping[str, Any]] | Iterable[Mapping[str, Any]],
+    area_ids: set[str],
+) -> dict[str, dict[str, Any]]:
+    raw_items = list(slices.values()) if isinstance(slices, Mapping) else list(slices)
+    normalized = [validate_learning_slice(item, area_ids) for item in raw_items]
+    _require_unique(normalized, "slice_id", "learning slice ID")
+    return {item["slice_id"]: item for item in normalized}
+
+
+def validate_learning_path(
+    data: Mapping[str, Any],
+    cycle: Mapping[str, Any] | None = None,
+    *,
+    slices: Mapping[str, Mapping[str, Any]] | Iterable[Mapping[str, Any]] | None = None,
+    assessment_report: Mapping[str, Any] | None = None,
+    assessment_spec: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    if not isinstance(data, Mapping):
+        raise SpecError("learning path must be an object")
+    cycle_id, title = _phase_header(data, "learning")
+    normalized_cycle = validate_cycle(cycle) if cycle is not None else None
+    if normalized_cycle and cycle_id != normalized_cycle["cycle_id"]:
+        raise SpecError("learning cycle_id does not match cycle.json")
+    cycle_area_ids = (
+        {area["area_id"] for area in normalized_cycle["areas"]}
+        if normalized_cycle
+        else None
+    )
+    raw_areas = data.get("areas")
+    if not isinstance(raw_areas, list) or not 3 <= len(raw_areas) <= 6:
+        raise SpecError("learning.areas must contain 3 to 6 areas")
+    declared_ids = {
+        _identifier(area.get("area_id") if isinstance(area, Mapping) else None, f"areas[{index}].area_id")
+        for index, area in enumerate(raw_areas)
+    }
+    if len(declared_ids) != len(raw_areas):
+        raise SpecError("Duplicate learning area_id")
+    if cycle_area_ids is not None and declared_ids != cycle_area_ids:
+        raise SpecError("learning areas must match cycle areas")
+
+    normalized_areas: list[dict[str, Any]] = []
+    all_slice_ids: list[str] = []
+    checkpoint_kernels: set[str] = set()
+    checkpoint_question_ids: set[str] = set()
+    for index, area in enumerate(raw_areas):
+        assert isinstance(area, Mapping)
+        area_id = _identifier(area.get("area_id"), f"areas[{index}].area_id")
+        slice_ids = _id_list(
+            area.get("slice_ids"), f"areas[{index}].slice_ids", minimum=5, maximum=10
+        )
+        checkpoint = _validate_question(
+            area.get("checkpoint"),
+            f"areas[{index}].checkpoint",
+            phase="learning",
+            area_ids=declared_ids,
+        )
+        if checkpoint["area_id"] != area_id:
+            raise SpecError(f"areas[{index}].checkpoint must belong to its area")
+        if checkpoint["knowledge_kernel_id"] in checkpoint_kernels:
+            raise SpecError("Learning checkpoints must use unique knowledge kernels")
+        checkpoint_kernels.add(checkpoint["knowledge_kernel_id"])
+        if checkpoint["question_id"] in checkpoint_question_ids:
+            raise SpecError("Learning checkpoints must use unique question IDs")
+        checkpoint_question_ids.add(checkpoint["question_id"])
+        all_slice_ids.extend(slice_ids)
+        normalized_areas.append(
+            {
+                "area_id": area_id,
+                "title": _nonempty(area.get("title"), f"areas[{index}].title", 240),
+                "slice_ids": slice_ids,
+                "checkpoint": checkpoint,
+            }
+        )
+    if len(set(all_slice_ids)) != len(all_slice_ids):
+        raise SpecError("Learning slice IDs must be globally unique")
+
+    normalized_slices: dict[str, dict[str, Any]] | None = None
+    if slices is not None:
+        normalized_slices = _slice_mapping(slices, declared_ids)
+        if set(normalized_slices) != set(all_slice_ids):
+            raise SpecError("learning path slice_ids must exactly match supplied slice files")
+        position = {slice_id: index for index, slice_id in enumerate(all_slice_ids)}
+        for area in normalized_areas:
+            previous_difficulty = -1
+            difficulty_rank = {"foundation": 0, "core": 1, "advanced": 2}
+            for expected_order, slice_id in enumerate(area["slice_ids"], start=1):
+                item = normalized_slices[slice_id]
+                if item["area_id"] != area["area_id"]:
+                    raise SpecError(f"Slice {slice_id} is listed under the wrong area")
+                if item["order"] != expected_order:
+                    raise SpecError(f"Slice {slice_id} order does not match the knowledge map")
+                current_difficulty = difficulty_rank[item["difficulty"]]
+                if current_difficulty < previous_difficulty:
+                    raise SpecError(
+                        f"Slice difficulty must progress from simple to complex: {slice_id}"
+                    )
+                previous_difficulty = current_difficulty
+                for prerequisite in item["prerequisites"]:
+                    if prerequisite not in normalized_slices:
+                        raise SpecError(f"Slice {slice_id} has an unknown prerequisite: {prerequisite}")
+                    if position[prerequisite] >= position[slice_id]:
+                        raise SpecError(
+                            f"Slice prerequisite must appear earlier in the knowledge map: {prerequisite} -> {slice_id}"
+                        )
+
+    normalized_assessment: dict[str, Any] | None = None
+    if assessment_spec is not None:
+        normalized_assessment = validate_assessment_spec(
+            assessment_spec, normalized_cycle
+        )
+        assessment_question_ids = {
+            item["question_id"] for item in normalized_assessment["questions"]
+        }
+        assessment_kernel_ids = {
+            item["knowledge_kernel_id"] for item in normalized_assessment["questions"]
+        }
+        collisions = sorted(checkpoint_question_ids & assessment_question_ids)
+        if collisions:
+            raise SpecError(
+                f"Learning checkpoint question IDs collide with Assessment: {collisions}"
+            )
+        kernel_collisions = sorted(checkpoint_kernels & assessment_kernel_ids)
+        if kernel_collisions:
+            raise SpecError(
+                "Learning checkpoint knowledge kernels collide with Assessment: "
+                f"{kernel_collisions}"
+            )
+        if normalized_slices is not None:
+            unknown_links = sorted(
+                {
+                    question_id
+                    for item in normalized_slices.values()
+                    for question_id in item["assessment_question_ids"]
+                    if question_id not in assessment_question_ids
+                }
+            )
+            if unknown_links:
+                raise SpecError(
+                    f"Learning slices reference unknown Assessment questions: {unknown_links}"
+                )
+
+    if assessment_report is not None:
+        gaps = assessment_report.get("gaps", [])
+        if not isinstance(gaps, list):
+            raise SpecError("assessment_report.gaps must be an array")
+        gap_ids_by_area: dict[str, set[str]] = {area_id: set() for area_id in declared_ids}
+        gap_source_question: dict[str, str] = {}
+        for index, gap in enumerate(gaps):
+            if not isinstance(gap, Mapping):
+                raise SpecError(f"assessment_report.gaps[{index}] must be an object")
+            area_id = _identifier(gap.get("area_id"), f"assessment_report.gaps[{index}].area_id")
+            if area_id not in declared_ids:
+                raise SpecError(f"Assessment gap references unknown area: {area_id}")
+            gap_id = _identifier(
+                gap.get("gap_id"), f"assessment_report.gaps[{index}].gap_id"
+            )
+            gap_ids_by_area[area_id].add(gap_id)
+            gap_source_question[gap_id] = _identifier(
+                gap.get("source_question_id"),
+                f"assessment_report.gaps[{index}].source_question_id",
+            )
+        for area in normalized_areas:
+            expected = min(10, 5 + len(gap_ids_by_area[area["area_id"]]))
+            if len(area["slice_ids"]) != expected:
+                raise SpecError(
+                    f"Area {area['area_id']} requires {expected} slices for its independent gaps"
+                )
+        if normalized_slices is None and gaps:
+            raise SpecError("slice files are required to validate assessment gap mapping")
+        mapped = {
+            gap_id
+            for item in (normalized_slices or {}).values()
+            for gap_id in item["addresses_gap_ids"]
+        }
+        required = {gap_id for area_gaps in gap_ids_by_area.values() for gap_id in area_gaps}
+        missing = sorted(required - mapped)
+        if missing:
+            raise SpecError(f"Every assessment gap must map to a learning slice: {missing}")
+        unknown = sorted(mapped - required)
+        if unknown:
+            raise SpecError(f"Learning slices reference unknown assessment gaps: {unknown}")
+        gap_area = {
+            gap_id: area_id
+            for area_id, area_gaps in gap_ids_by_area.items()
+            for gap_id in area_gaps
+        }
+        for item in (normalized_slices or {}).values():
+            wrong_area = [
+                gap_id
+                for gap_id in item["addresses_gap_ids"]
+                if gap_area[gap_id] != item["area_id"]
+            ]
+            if wrong_area:
+                raise SpecError(
+                    f"Slice {item['slice_id']} maps gaps from another area: {wrong_area}"
+                )
+            missing_sources = [
+                gap_id
+                for gap_id in item["addresses_gap_ids"]
+                if gap_source_question[gap_id]
+                not in item["assessment_question_ids"]
+            ]
+            if missing_sources:
+                raise SpecError(
+                    f"Slice {item['slice_id']} must link each addressed gap's source question: "
+                    f"{missing_sources}"
+                )
+
+    return {
+        "schema_version": 3,
+        "phase": "learning",
+        "cycle_id": cycle_id,
+        "title": title,
+        "areas": normalized_areas,
+    }
+
+
+def _question_index(spec: Mapping[str, Any]) -> dict[str, dict[str, Any]]:
+    return {item["question_id"]: item for item in spec["questions"]}
+
+
+def _kernel_index(
+    assessment_spec: Mapping[str, Any], learning_path: Mapping[str, Any] | None = None
+) -> dict[str, dict[str, Any]]:
+    index = {item["knowledge_kernel_id"]: item for item in assessment_spec["questions"]}
+    if learning_path:
+        for area in learning_path["areas"]:
+            checkpoint = area["checkpoint"]
+            if checkpoint["knowledge_kernel_id"] in index:
+                raise SpecError("Checkpoint kernel collides with an assessment kernel")
+            index[checkpoint["knowledge_kernel_id"]] = checkpoint
+    return index
+
+
+def _required_primary_gap_kernels(
+    gaps: Iterable[Mapping[str, Any]],
+    area_order: list[str],
+    question_count: int,
+) -> set[str]:
+    """Choose the highest-priority gaps that can receive direct scoring.
+
+    A capped Review can contain fewer questions than prior independent gaps.
+    Areas with no gap still need one primary question for area coverage, so
+    those questions are reserved before allocating the remaining capacity.
+    """
+
+    unique: dict[str, dict[str, Any]] = {}
+    for position, gap in enumerate(gaps):
+        kernel_id = str(gap["knowledge_kernel_id"])
+        if kernel_id not in unique:
+            unique[kernel_id] = {**gap, "_position": position}
+
+    gap_areas = {str(gap["area_id"]) for gap in unique.values()}
+    reserved_for_gap_free_areas = len(set(area_order) - gap_areas)
+    capacity = min(
+        len(unique),
+        max(0, question_count - reserved_for_gap_free_areas),
+    )
+
+    def priority(gap: Mapping[str, Any]) -> tuple[int, int, int]:
+        source_rank = 0 if gap.get("source") == "assessment" else 1
+        critical_rank = 0 if gap.get("critical") is True else 1
+        return source_rank, critical_rank, int(gap["_position"])
+
+    required: list[str] = []
+    # First make gap-bearing areas visible in direct scoring, using the best
+    # candidate in each area. The ordinary all-area validator reserves the
+    # remaining questions for areas that had no prior gap.
+    for area_id in area_order:
+        candidates = [
+            gap for gap in unique.values() if gap["area_id"] == area_id
+        ]
+        if candidates:
+            chosen = min(candidates, key=priority)["knowledge_kernel_id"]
+            if chosen not in required:
+                required.append(chosen)
+
+    for gap in sorted(unique.values(), key=priority):
+        kernel_id = str(gap["knowledge_kernel_id"])
+        if kernel_id not in required:
+            required.append(kernel_id)
+        if len(required) >= capacity:
+            break
+    return set(required[:capacity])
+
+
+def validate_review_spec(
+    data: Mapping[str, Any],
+    cycle: Mapping[str, Any],
+    *,
+    assessment_spec: Mapping[str, Any],
+    learning_path: Mapping[str, Any] | None = None,
+    learning_slices: Mapping[str, Mapping[str, Any]] | Iterable[Mapping[str, Any]] | None = None,
+    assessment_report: Mapping[str, Any] | None = None,
+    learning_report: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    if not isinstance(data, Mapping):
+        raise SpecError("review spec must be an object")
+    cycle_id, title = _phase_header(data, "review")
+    normalized_cycle = validate_cycle(cycle)
+    if cycle_id != normalized_cycle["cycle_id"]:
+        raise SpecError("review cycle_id does not match cycle.json")
+    normalized_assessment = validate_assessment_spec(assessment_spec, normalized_cycle)
+    normalized_learning = (
+        validate_learning_path(
+            learning_path,
+            normalized_cycle,
+            slices=learning_slices,
+            assessment_report=assessment_report,
+            assessment_spec=normalized_assessment,
+        )
+        if learning_path is not None
+        else None
+    )
+    area_order = [area["area_id"] for area in normalized_cycle["areas"]]
+    area_ids = set(area_order)
+    questions = data.get("questions")
+    if not isinstance(questions, list) or not 8 <= len(questions) <= 15:
+        raise SpecError("review.questions must contain 8 to 15 questions")
+    normalized_questions = [
+        _validate_question(
+            question,
+            f"questions[{index}]",
+            phase="review",
+            area_ids=area_ids,
+            review=True,
+        )
+        for index, question in enumerate(questions)
+    ]
+    _require_unique(normalized_questions, "question_id", "review question ID")
+    _require_unique(normalized_questions, "scenario_id", "review scenario ID")
+    _require_unique(normalized_questions, "scenario_fingerprint", "review scenario fingerprint")
+
+    source_by_id = _question_index(normalized_assessment)
+    if normalized_learning:
+        for area in normalized_learning["areas"]:
+            source_by_id[area["checkpoint"]["question_id"]] = area["checkpoint"]
+    sources_by_kernel = _kernel_index(normalized_assessment, normalized_learning)
+    known_kernels = set(sources_by_kernel)
+    prior_fingerprints = {
+        item["scenario_fingerprint"] for item in normalized_assessment["questions"]
+    }
+    prior_scenario_ids = {
+        item["scenario_id"] for item in normalized_assessment["questions"]
+    }
+    prior_scenario_contexts = [
+        item["scenario_context"] for item in normalized_assessment["questions"]
+    ]
+    if normalized_learning:
+        checkpoint_questions = [
+            area["checkpoint"] for area in normalized_learning["areas"]
+        ]
+        prior_fingerprints.update(
+            item["scenario_fingerprint"] for item in checkpoint_questions
+        )
+        prior_scenario_ids.update(
+            item["scenario_id"] for item in checkpoint_questions
+        )
+        prior_scenario_contexts.extend(
+            item["scenario_context"] for item in checkpoint_questions
+        )
+    example_fingerprints: set[str] = set()
+    example_scenario_ids: set[str] = set()
+    slice_ids: set[str] = set()
+    if learning_slices is not None:
+        normalized_slice_map = _slice_mapping(learning_slices, area_ids)
+        slice_ids = set(normalized_slice_map)
+        example_fingerprints = {
+            item["worked_example"]["scenario_fingerprint"]
+            for item in normalized_slice_map.values()
+        }
+        example_scenario_ids = {
+            item["worked_example"]["scenario_id"]
+            for item in normalized_slice_map.values()
+        }
+        prior_scenario_contexts.extend(
+            item["worked_example"]["scenario_context"]
+            for item in normalized_slice_map.values()
+        )
+
+    assessment_question_ids = set(_question_index(normalized_assessment))
+    checkpoint_question_ids = {
+        area["checkpoint"]["question_id"] for area in (normalized_learning or {}).get("areas", [])
+    }
+
+    for index, question in enumerate(normalized_questions):
+        field = f"questions[{index}]"
+        source = source_by_id.get(question["source_question_id"])
+        if source is None:
+            raise SpecError(f"{field}.source_question_id does not exist")
+        if source["knowledge_kernel_id"] != question["primary_kernel_id"]:
+            raise SpecError(f"{field}.primary_kernel_id must match its source question")
+        if source["area_id"] != question["area_id"]:
+            raise SpecError(f"{field}.area_id must match its primary source question")
+        if question["core_proposition"] != source["core_proposition"]:
+            raise SpecError(f"{field} must preserve the source core_proposition")
+        unknown_integrated = set(question["integrated_kernel_ids"]) - known_kernels
+        if unknown_integrated:
+            raise SpecError(f"{field} references unknown integrated kernels: {sorted(unknown_integrated)}")
+        if question["scenario_id"] in prior_scenario_ids | example_scenario_ids:
+            raise SpecError(f"{field} must use a new scenario_id")
+        if question["scenario_fingerprint"] in prior_fingerprints | example_fingerprints:
+            raise SpecError(
+                f"{field} reuses an assessment, checkpoint, or learning scenario"
+            )
+        if any(
+            _near_duplicate(question["scenario_context"], context)
+            for context in prior_scenario_contexts
+        ):
+            raise SpecError(f"{field} is a near-duplicate of a prior scenario")
+        if question["question_family"] == source["question_family"]:
+            raise SpecError(f"{field} must change question_family")
+        if _normalize_text(question["prompt"]) == _normalize_text(source["prompt"]):
+            raise SpecError(f"{field} must change the prompt")
+        source_ids = {item["id"] for item in source["options"]}
+        review_ids = {item["id"] for item in question["options"]}
+        if source_ids & review_ids:
+            raise SpecError(f"{field} must use new option IDs")
+        source_labels = {_normalize_text(item["label"]) for item in source["options"]}
+        review_labels = {_normalize_text(item["label"]) for item in question["options"]}
+        if source_labels & review_labels:
+            raise SpecError(f"{field} must rewrite every option label")
+        source_descriptions = {
+            _normalize_text(item["description"]) for item in source["options"]
+        }
+        review_descriptions = {
+            _normalize_text(item["description"]) for item in question["options"]
+        }
+        if source_descriptions & review_descriptions:
+            raise SpecError(f"{field} must rewrite every option description")
+        source_explanations = {
+            _normalize_text(item["explanation"]) for item in source["options"]
+        }
+        review_explanations = {
+            _normalize_text(item["explanation"]) for item in question["options"]
+        }
+        if source_explanations & review_explanations:
+            raise SpecError(f"{field} must rewrite every option explanation")
+        source_position = [item["id"] for item in source["options"]].index(
+            source["correct_option_id"]
+        )
+        review_position = [item["id"] for item in question["options"]].index(
+            question["correct_option_id"]
+        )
+        if source_position == review_position:
+            raise SpecError(f"{field} must rotate the correct-answer position")
+        lineage = question["lineage"]
+        if source["question_id"] in _question_index(normalized_assessment):
+            if source["question_id"] not in lineage["assessment_question_ids"]:
+                raise SpecError(f"{field}.lineage must include its assessment source")
+        elif source["question_id"] not in lineage["learning_checkpoint_ids"]:
+            raise SpecError(f"{field}.lineage must include its learning checkpoint source")
+        for kernel_id in question["integrated_kernel_ids"]:
+            integrated_source = sources_by_kernel[kernel_id]
+            if integrated_source["question_id"] in _question_index(normalized_assessment):
+                if integrated_source["question_id"] not in lineage["assessment_question_ids"]:
+                    raise SpecError(
+                        f"{field}.lineage must include every integrated assessment source"
+                    )
+            elif integrated_source["question_id"] not in lineage["learning_checkpoint_ids"]:
+                raise SpecError(
+                    f"{field}.lineage must include every integrated checkpoint source"
+                )
+        unknown_slices = set(lineage["learning_slice_ids"]) - slice_ids
+        if learning_slices is not None and unknown_slices:
+            raise SpecError(f"{field}.lineage references unknown learning slices")
+        unknown_assessment = (
+            set(lineage["assessment_question_ids"]) - assessment_question_ids
+        )
+        if unknown_assessment:
+            raise SpecError(
+                f"{field}.lineage references unknown Assessment questions: {sorted(unknown_assessment)}"
+            )
+        unknown_checkpoints = (
+            set(lineage["learning_checkpoint_ids"]) - checkpoint_question_ids
+        )
+        if unknown_checkpoints:
+            raise SpecError(
+                f"{field}.lineage references unknown Learning checkpoints: {sorted(unknown_checkpoints)}"
+            )
+
+    covered_areas = {question["area_id"] for question in normalized_questions}
+    missing_areas = sorted(area_ids - covered_areas)
+    if missing_areas:
+        raise SpecError(f"Review must cover every major area: {missing_areas}")
+
+    has_cross_area_integration = any(
+        any(
+            sources_by_kernel[kernel_id]["area_id"] != question["area_id"]
+            for kernel_id in question["integrated_kernel_ids"]
+        )
+        for question in normalized_questions
+    )
+    if not has_cross_area_integration:
+        raise SpecError("Review requires at least one cross-area integrated question")
+
+    gaps = _combined_gap_records(assessment_report, learning_report)
+    if assessment_report is not None or learning_report is not None:
+        gap_kernels = {gap["knowledge_kernel_id"] for gap in gaps}
+        unknown_gap_kernels = sorted(gap_kernels - known_kernels)
+        if unknown_gap_kernels:
+            raise SpecError(
+                f"Reports reference unknown gap kernels: {unknown_gap_kernels}"
+            )
+        unknown_gap_areas = sorted(
+            {gap["area_id"] for gap in gaps} - area_ids
+        )
+        if unknown_gap_areas:
+            raise SpecError(
+                f"Reports reference unknown gap areas: {unknown_gap_areas}"
+            )
+        expected = clamp(len(gap_kernels) + len(area_ids), 8, 15)
+        if len(normalized_questions) != expected:
+            raise SpecError(f"Review requires {expected} questions for current gaps and areas")
+        primary_covered = {
+            question["primary_kernel_id"] for question in normalized_questions
+        }
+        required_primary = _required_primary_gap_kernels(
+            gaps, area_order, len(normalized_questions)
+        )
+        missing_primary = sorted(required_primary - primary_covered)
+        if missing_primary:
+            raise SpecError(
+                "Review primary kernels omit capacity-prioritized gaps: "
+                f"{missing_primary}"
+            )
+        all_covered = {
+            kernel_id
+            for question in normalized_questions
+            for kernel_id in [
+                question["primary_kernel_id"],
+                *question["integrated_kernel_ids"],
+            ]
+        }
+        missing_gap_coverage = sorted(gap_kernels - all_covered)
+        if missing_gap_coverage:
+            raise SpecError(
+                "Every prior gap kernel must appear as primary or integrated: "
+                f"{missing_gap_coverage}"
+            )
+        result_by_question = {
+            item.get("question_id"): item
+            for item in (assessment_report or {}).get("question_results", [])
+            if isinstance(item, Mapping)
+        }
+        critical_correct = {
+            question["knowledge_kernel_id"]
+            for question in normalized_assessment["questions"]
+            if question["importance"] >= 8
+            and result_by_question.get(question["question_id"], {}).get("is_correct") is True
+        }
+        missing_critical = sorted(critical_correct - all_covered)
+        if missing_critical:
+            raise SpecError(
+                f"Review must include mission-critical correct kernels: {missing_critical}"
+            )
+
+    return {
+        "schema_version": 3,
+        "phase": "review",
+        "cycle_id": cycle_id,
+        "cycle_contract_digest": _cycle_contract_digest(normalized_cycle),
+        "title": title,
+        "instructions": _nonempty(data.get("instructions"), "instructions", 2000),
+        "questions": normalized_questions,
+    }
+
+
+def _combined_gap_records(
+    assessment_report: Mapping[str, Any] | None,
+    learning_report: Mapping[str, Any] | None,
+) -> list[dict[str, Any]]:
+    result: dict[str, dict[str, Any]] = {}
+    for report in (assessment_report, learning_report):
+        if report is None:
+            continue
+        gaps = report.get("gaps", [])
+        if not isinstance(gaps, list):
+            raise SpecError("report.gaps must be an array")
+        for index, gap in enumerate(gaps):
+            if not isinstance(gap, Mapping):
+                raise SpecError(f"report.gaps[{index}] must be an object")
+            gap_id = _identifier(gap.get("gap_id"), f"report.gaps[{index}].gap_id")
+            source = gap.get("source")
+            if source is None:
+                source = (
+                    "assessment"
+                    if gap_id.startswith("assessment.")
+                    else "learning_checkpoint"
+                )
+            if source not in {"assessment", "learning_checkpoint"}:
+                raise SpecError(
+                    f"report.gaps[{index}].source must be assessment or learning_checkpoint"
+                )
+            critical = gap.get("critical", False)
+            if not isinstance(critical, bool):
+                raise SpecError(f"report.gaps[{index}].critical must be boolean")
+            result[gap_id] = {
+                "gap_id": gap_id,
+                "source": source,
+                "area_id": _identifier(gap.get("area_id"), f"report.gaps[{index}].area_id"),
+                "knowledge_kernel_id": _identifier(
+                    gap.get("knowledge_kernel_id"),
+                    f"report.gaps[{index}].knowledge_kernel_id",
+                ),
+                "source_question_id": _identifier(
+                    gap.get("source_question_id"),
+                    f"report.gaps[{index}].source_question_id",
+                ),
+                "core_proposition": _optional(
+                    gap.get("core_proposition"),
+                    f"report.gaps[{index}].core_proposition",
+                    2400,
+                ),
+                "critical": critical,
+            }
+    return list(result.values())
+
+
+def _find_question(spec: Mapping[str, Any], question_id: str) -> dict[str, Any]:
+    for question in spec.get("questions", []):
+        if question["question_id"] == question_id:
+            return question
+    raise SpecError(f"Unknown question_id: {question_id}")
+
+
+def _batch_spec_digest(spec: Mapping[str, Any]) -> str:
+    if spec.get("phase") not in {"assessment", "review"}:
+        raise SpecError("Batch manifests support Assessment or Review specs")
+    return _content_digest(spec)
+
+
+def validate_batch_manifest(
+    phase_dir: Path,
+    spec: Mapping[str, Any],
+    *,
+    required: bool = False,
+) -> dict[str, Any] | None:
+    """Validate the write-once digest that seals an entire question batch."""
+
+    path = _contained_child(phase_dir, "batch-manifest.json")
+    if path.exists() and not path.is_file():
+        raise SpecError(f"Batch manifest path is not a file: {path}")
+    if not path.is_file():
+        if required:
+            raise SpecError(f"Batch manifest is missing: {path}")
+        return None
+    record = read_json_object(path)
+    expected = {
+        "schema_version": 3,
+        "record_type": "batch_manifest",
+        "phase": spec.get("phase"),
+        "cycle_id": spec.get("cycle_id"),
+        "cycle_contract_digest": spec.get("cycle_contract_digest"),
+        "spec_digest": _batch_spec_digest(spec),
+        "question_ids": [item["question_id"] for item in spec.get("questions", [])],
+    }
+    for field, value in expected.items():
+        if record.get(field) != value:
+            raise SpecError(f"Batch manifest {field} mismatch: {path}")
+    _rfc3339(record.get("sealed_at"), f"{path}.sealed_at")
+    return record
+
+
+def ensure_batch_manifest(
+    phase_dir: Path, spec: Mapping[str, Any]
+) -> tuple[dict[str, Any], bool]:
+    """Seal a complete normalized batch before its first learner action."""
+
+    existing = validate_batch_manifest(phase_dir, spec)
+    if existing is not None:
+        validate_choice_label_contract(spec, check_future_surfaces=False)
+        return existing, False
+    validate_choice_description_contract(spec)
+    record = {
+        "schema_version": 3,
+        "record_type": "batch_manifest",
+        "phase": spec["phase"],
+        "cycle_id": spec["cycle_id"],
+        "cycle_contract_digest": spec.get("cycle_contract_digest"),
+        "spec_digest": _batch_spec_digest(spec),
+        "question_ids": [item["question_id"] for item in spec["questions"]],
+        "sealed_at": utc_now(),
+    }
+    path = _contained_child(phase_dir, "batch-manifest.json")
+    try:
+        write_json_once(path, record)
+    except FileExistsError:
+        committed = validate_batch_manifest(phase_dir, spec, required=True)
+        assert committed is not None
+        return committed, False
+    return record, True
+
+
+def _validate_display_order(question: Mapping[str, Any], order: Iterable[str]) -> list[str]:
+    if not isinstance(order, list):
+        raise SpecError("displayed_option_order must be an array")
+    normalized = [_identifier(item, f"displayed_option_order[{index}]") for index, item in enumerate(order)]
+    expected = {item["id"] for item in question["options"]}
+    if len(normalized) != len(expected) or set(normalized) != expected:
+        raise SpecError("displayed_option_order must be an exact option permutation")
+    return normalized
+
+
+def _idempotent_existing(
+    path: Path, *, request_id: str, selected_option_id: str | None = None
+) -> tuple[dict[str, Any], bool]:
+    existing = read_json_object(path)
+    same_selection = (
+        selected_option_id is None
+        or existing.get("selected_option_id") == selected_option_id
+    )
+    # The committed answer is the idempotency key at question scope.  A client
+    # may legitimately generate a fresh request ID after an uncertain timeout.
+    if same_selection:
+        return existing, False
+    raise ConflictError(f"Immutable record already committed: {path}")
+
+
+def record_response(
+    phase_dir: Path,
+    spec: Mapping[str, Any],
+    question_id: str,
+    selected_option_id: str,
+    displayed_option_order: list[str],
+    request_id: str,
+) -> tuple[dict[str, Any], bool]:
+    """Commit one Assessment/Review answer with request-level idempotency."""
+
+    phase = spec.get("phase")
+    if phase not in {"assessment", "review"}:
+        raise SpecError("record_response supports assessment or review specs")
+    question_id = _identifier(question_id, "question_id")
+    selected_option_id = _identifier(selected_option_id, "selected_option_id")
+    request_id = _identifier(request_id, "request_id")
+    question = _find_question(spec, question_id)
+    order = _validate_display_order(question, displayed_option_order)
+    options = {item["id"]: item for item in question["options"]}
+    if selected_option_id not in options:
+        raise SpecError("selected_option_id is not a valid option")
+    selected = options[selected_option_id]
+    is_correct = selected_option_id == question["correct_option_id"]
+    manifest, _ = ensure_batch_manifest(phase_dir, spec)
+    record = {
+        "schema_version": 3,
+        "record_type": "question_response",
+        "phase": phase,
+        "cycle_id": spec["cycle_id"],
+        "question_id": question_id,
+        "batch_spec_digest": manifest["spec_digest"],
+        "question_digest": _question_digest(question),
+        "area_id": question["area_id"],
+        "concept_id": question["concept_id"],
+        "knowledge_kernel_id": question["knowledge_kernel_id"],
+        "primary_kernel_id": question.get("primary_kernel_id"),
+        "integrated_kernel_ids": question.get("integrated_kernel_ids", []),
+        "scenario_id": question["scenario_id"],
+        "scenario_fingerprint": question["scenario_fingerprint"],
+        "question_family": question["question_family"],
+        "lineage": question.get("lineage", {}),
+        "displayed_option_order": order,
+        "selected_option_id": selected_option_id,
+        "selected_misconception_tag": selected["misconception_tag"] or None,
+        "correct_option_id": question["correct_option_id"],
+        "is_correct": is_correct,
+        "independence": "independent" if phase == "assessment" else "feedback_exposed",
+        "feedback_exposed": phase == "review",
+        "feedback_timing": "immediate_after_commit",
+        "request_id": request_id,
+        "answered_at": utc_now(),
+    }
+    path = _contained_child(phase_dir, "responses", f"{question_id}.json")
+    if path.exists():
+        _responses_for(phase_dir, spec, require_complete=False)
+        return _idempotent_existing(
+            path, request_id=request_id, selected_option_id=selected_option_id
+        )
+    try:
+        write_json_once(path, record)
+    except FileExistsError:
+        _responses_for(phase_dir, spec, require_complete=False)
+        return _idempotent_existing(
+            path, request_id=request_id, selected_option_id=selected_option_id
+        )
+    return record, True
+
+
+def _responses_for(
+    phase_dir: Path,
+    spec: Mapping[str, Any],
+    *,
+    require_complete: bool,
+) -> tuple[dict[str, dict[str, Any]], list[str]]:
+    records: dict[str, dict[str, Any]] = {}
+    missing: list[str] = []
+    expected_names = {f"{question['question_id']}.json" for question in spec["questions"]}
+    responses_dir = _contained_child(phase_dir, "responses")
+    if responses_dir.exists() and not responses_dir.is_dir():
+        raise SpecError(f"Responses path is not a directory: {responses_dir}")
+    response_paths = list(responses_dir.glob("*.json")) if responses_dir.is_dir() else []
+    manifest = validate_batch_manifest(
+        phase_dir, spec, required=bool(response_paths)
+    )
+    batch_spec_digest = _batch_spec_digest(spec)
+    if responses_dir.is_dir():
+        unexpected = sorted(
+            path.name
+            for path in response_paths
+            if path.name not in expected_names
+        )
+        if unexpected:
+            raise SpecError(f"Unexpected response files: {unexpected}")
+    for question in spec["questions"]:
+        path = _contained_child(
+            phase_dir, "responses", f"{question['question_id']}.json"
+        )
+        if path.exists() and not path.is_file():
+            raise SpecError(f"Response path is not a file: {path}")
+        if not path.is_file():
+            missing.append(question["question_id"])
+            continue
+        record = read_json_object(path)
+        expected_identity = {
+            "schema_version": 3,
+            "record_type": "question_response",
+            "phase": spec["phase"],
+            "cycle_id": spec["cycle_id"],
+            "question_id": question["question_id"],
+            "batch_spec_digest": batch_spec_digest,
+            "question_digest": _question_digest(question),
+            "area_id": question["area_id"],
+            "concept_id": question["concept_id"],
+            "knowledge_kernel_id": question["knowledge_kernel_id"],
+            "primary_kernel_id": question.get("primary_kernel_id"),
+            "integrated_kernel_ids": question.get("integrated_kernel_ids", []),
+            "scenario_id": question["scenario_id"],
+            "scenario_fingerprint": question["scenario_fingerprint"],
+            "question_family": question["question_family"],
+            "lineage": question.get("lineage", {}),
+            "correct_option_id": question["correct_option_id"],
+            "independence": (
+                "independent" if spec["phase"] == "assessment" else "feedback_exposed"
+            ),
+            "feedback_exposed": spec["phase"] == "review",
+            "feedback_timing": "immediate_after_commit",
+        }
+        for field, value in expected_identity.items():
+            if record.get(field) != value:
+                raise SpecError(f"Response {field} mismatch: {path}")
+        _validate_display_order(question, record.get("displayed_option_order"))
+        options = {item["id"]: item for item in question["options"]}
+        selected_option_id = record.get("selected_option_id")
+        if selected_option_id not in options:
+            raise SpecError(f"Response selected option mismatch: {path}")
+        expected_correct = selected_option_id == question["correct_option_id"]
+        if record.get("is_correct") is not expected_correct:
+            raise SpecError(f"Response correctness mismatch: {path}")
+        expected_misconception = options[selected_option_id]["misconception_tag"] or None
+        if record.get("selected_misconception_tag") != expected_misconception:
+            raise SpecError(f"Response misconception mismatch: {path}")
+        _identifier(record.get("request_id"), f"{path}.request_id")
+        _rfc3339(record.get("answered_at"), f"{path}.answered_at")
+        records[question["question_id"]] = record
+    if records and manifest is None:
+        raise SpecError("Responses require a sealed batch manifest")
+    if require_complete and missing:
+        raise IncompletePhaseError(f"Missing responses: {missing}")
+    return records, missing
+
+
+def response_completion_state(
+    phase_dir: Path, spec: Mapping[str, Any]
+) -> dict[str, Any]:
+    """Validate responses and expose a strict sequential completion prefix."""
+
+    records, _ = _responses_for(phase_dir, spec, require_complete=False)
+    question_ids = [question["question_id"] for question in spec["questions"]]
+    completed_ids: list[str] = []
+    missing_seen = False
+    for question_id in question_ids:
+        if question_id in records:
+            if missing_seen:
+                raise SpecError(f"Responses are out of order at {question_id}")
+            completed_ids.append(question_id)
+        else:
+            missing_seen = True
+    return {
+        "complete": len(completed_ids) == len(question_ids),
+        "completed_question_ids": completed_ids,
+        "completed": len(completed_ids),
+        "total": len(question_ids),
+        "next_question_id": (
+            question_ids[len(completed_ids)]
+            if len(completed_ids) < len(question_ids)
+            else None
+        ),
+    }
+
+
+def _signal(correct: int, total: int) -> str:
+    ratio = correct / total if total else 0
+    if ratio >= 0.8:
+        return "stable_signal"
+    if ratio >= 0.5:
+        return "mixed_signal"
+    return "needs_support"
+
+
+def build_assessment_report(
+    phase_dir: Path,
+    spec: Mapping[str, Any],
+    *,
+    require_complete: bool = True,
+    persist: bool = False,
+) -> dict[str, Any]:
+    responses, missing = _responses_for(phase_dir, spec, require_complete=require_complete)
+    area_order = list(spec["area_ids"])
+    area_results: list[dict[str, Any]] = []
+    gaps: list[dict[str, Any]] = []
+    strengths: list[dict[str, Any]] = []
+    question_results: list[dict[str, Any]] = []
+    total_correct = 0
+    for area_id in area_order:
+        questions = [item for item in spec["questions"] if item["area_id"] == area_id]
+        answered = [item for item in questions if item["question_id"] in responses]
+        correct = sum(bool(responses[item["question_id"]]["is_correct"]) for item in answered)
+        total_correct += correct
+        signal = _signal(correct, len(answered)) if answered else "needs_support"
+        area_gap_ids: list[str] = []
+        for question in answered:
+            response = responses[question["question_id"]]
+            result = {
+                "question_id": question["question_id"],
+                "area_id": area_id,
+                "knowledge_kernel_id": question["knowledge_kernel_id"],
+                "core_proposition": question["core_proposition"],
+                "sources": question["sources"],
+                "is_correct": response["is_correct"],
+                "selected_option_id": response["selected_option_id"],
+                "misconception_tag": response.get("selected_misconception_tag"),
+            }
+            question_results.append(result)
+            if response["is_correct"]:
+                strengths.append(
+                    {
+                        "source_question_id": question["question_id"],
+                        "area_id": area_id,
+                        "knowledge_kernel_id": question["knowledge_kernel_id"],
+                        "core_proposition": question["core_proposition"],
+                        "importance": question["importance"],
+                        "sources": question["sources"],
+                    }
+                )
+            else:
+                gap_id = f"assessment.{question['question_id']}"
+                area_gap_ids.append(gap_id)
+                gaps.append(
+                    {
+                        "gap_id": gap_id,
+                        "source": "assessment",
+                        "source_question_id": question["question_id"],
+                        "area_id": area_id,
+                        "knowledge_kernel_id": question["knowledge_kernel_id"],
+                        "core_proposition": question["core_proposition"],
+                        "sources": question["sources"],
+                        "misconception_tag": response.get("selected_misconception_tag"),
+                        "critical": question["importance"] >= 8,
+                    }
+                )
+        area_results.append(
+            {
+                "area_id": area_id,
+                "answered": len(answered),
+                "total": len(questions),
+                "correct": correct,
+                "accuracy": correct / len(answered) if answered else 0,
+                "signal": signal,
+                "signal_label": SIGNAL_LABELS[signal],
+                "strength_question_ids": [
+                    item["question_id"]
+                    for item in answered
+                    if responses[item["question_id"]]["is_correct"]
+                ],
+                "wrong_question_ids": [
+                    item["question_id"]
+                    for item in answered
+                    if not responses[item["question_id"]]["is_correct"]
+                ],
+                "gap_ids": area_gap_ids,
+                "critical_gap_ids": [
+                    gap["gap_id"]
+                    for gap in gaps
+                    if gap["area_id"] == area_id and gap["critical"]
+                ],
+                "suggested_slice_count": min(10, 5 + len(set(area_gap_ids))),
+                "confidence": "medium" if len(answered) >= 3 else "low",
+            }
+        )
+    report = {
+        "schema_version": 3,
+        "report_type": "assessment_report",
+        "cycle_id": spec["cycle_id"],
+        "complete": not missing,
+        "answered": len(responses),
+        "total": len(spec["questions"]),
+        "correct": total_correct,
+        "area_results": area_results,
+        "question_results": question_results,
+        "strengths": strengths,
+        "gaps": gaps,
+        "critical_gap_ids": [gap["gap_id"] for gap in gaps if gap["critical"]],
+        "missing_question_ids": missing,
+        "evidence_limitations": [
+            "Immediate feedback means later same-kernel evidence is feedback-exposed.",
+            "Choice responses do not prove end-to-end execution by themselves.",
+        ],
+        "generated_at": utc_now(),
+    }
+    if persist:
+        atomic_write_json(_contained_child(phase_dir, "report.json"), report)
+    return report
+
+
+def _learning_event_path(learning_dir: Path, event_type: str, subject_id: str) -> Path:
+    return _contained_child(
+        learning_dir, "events", f"{event_type}.{subject_id}.json"
+    )
+
+
+def _learning_sequence(path_spec: Mapping[str, Any]) -> list[tuple[str, str]]:
+    sequence: list[tuple[str, str]] = []
+    for area in path_spec["areas"]:
+        sequence.extend(("slice_completed", slice_id) for slice_id in area["slice_ids"])
+        sequence.append(("checkpoint_answered", area["area_id"]))
+    return sequence
+
+
+def _slice_map_for_path(
+    path_spec: Mapping[str, Any],
+    slices: Mapping[str, Mapping[str, Any]] | Iterable[Mapping[str, Any]],
+) -> dict[str, dict[str, Any]]:
+    area_ids = {area["area_id"] for area in path_spec["areas"]}
+    slice_map = _slice_mapping(slices, area_ids)
+    required = {
+        slice_id for area in path_spec["areas"] for slice_id in area["slice_ids"]
+    }
+    if set(slice_map) != required:
+        raise SpecError("Learning event validation requires the exact slice set")
+    return slice_map
+
+
+def _learning_contract_digest(
+    path_spec: Mapping[str, Any], slice_map: Mapping[str, Mapping[str, Any]]
+) -> str:
+    ordered_slices = [
+        slice_map[slice_id]
+        for area in path_spec["areas"]
+        for slice_id in area["slice_ids"]
+    ]
+    return _content_digest({"path": path_spec, "slices": ordered_slices})
+
+
+def _validate_slice_event(
+    path: Path,
+    record: Mapping[str, Any],
+    path_spec: Mapping[str, Any],
+    item: Mapping[str, Any],
+    contract_digest: str,
+) -> dict[str, Any]:
+    expected = {
+        "schema_version": 3,
+        "record_type": "learning_event",
+        "event_type": "slice_completed",
+        "cycle_id": path_spec["cycle_id"],
+        "slice_id": item["slice_id"],
+        "area_id": item["area_id"],
+        "learning_contract_digest": contract_digest,
+        "slice_digest": _slice_digest(item),
+        "mastery_effect": "progress_only",
+    }
+    for field, value in expected.items():
+        if record.get(field) != value:
+            raise SpecError(f"Slice completion {field} mismatch: {path}")
+    _identifier(record.get("request_id"), f"{path}.request_id")
+    _rfc3339(record.get("completed_at"), f"{path}.completed_at")
+    return dict(record)
+
+
+def _validate_checkpoint_event(
+    path: Path,
+    record: Mapping[str, Any],
+    path_spec: Mapping[str, Any],
+    area: Mapping[str, Any],
+    contract_digest: str,
+) -> dict[str, Any]:
+    question = area["checkpoint"]
+    expected_identity = {
+        "schema_version": 3,
+        "record_type": "learning_event",
+        "event_type": "checkpoint_answered",
+        "cycle_id": path_spec["cycle_id"],
+        "area_id": area["area_id"],
+        "question_id": question["question_id"],
+        "learning_contract_digest": contract_digest,
+        "question_digest": _question_digest(question),
+        "knowledge_kernel_id": question["knowledge_kernel_id"],
+        "concept_id": question["concept_id"],
+        "scenario_id": question["scenario_id"],
+        "scenario_fingerprint": question["scenario_fingerprint"],
+        "question_family": question["question_family"],
+        "correct_option_id": question["correct_option_id"],
+        "independence": "feedback_exposed",
+        "feedback_exposed": True,
+        "feedback_timing": "immediate_after_commit",
+    }
+    for field, value in expected_identity.items():
+        if record.get(field) != value:
+            raise SpecError(f"Checkpoint {field} mismatch: {path}")
+    _validate_display_order(question, record.get("displayed_option_order"))
+    options = {item["id"]: item for item in question["options"]}
+    selected_option_id = record.get("selected_option_id")
+    if selected_option_id not in options:
+        raise SpecError(f"Checkpoint selected option mismatch: {path}")
+    selected = options[selected_option_id]
+    expected_correct = selected_option_id == question["correct_option_id"]
+    if record.get("is_correct") is not expected_correct:
+        raise SpecError(f"Checkpoint correctness mismatch: {path}")
+    expected_misconception = selected["misconception_tag"] or None
+    if record.get("selected_misconception_tag") != expected_misconception:
+        raise SpecError(f"Checkpoint misconception mismatch: {path}")
+    _identifier(record.get("request_id"), f"{path}.request_id")
+    _rfc3339(record.get("answered_at"), f"{path}.answered_at")
+    return dict(record)
+
+
+def _validated_learning_records(
+    learning_dir: Path,
+    path_spec: Mapping[str, Any],
+    slices: Mapping[str, Mapping[str, Any]] | Iterable[Mapping[str, Any]],
+) -> tuple[dict[str, dict[str, Any]], dict[str, dict[str, Any]], list[str]]:
+    slice_map = _slice_map_for_path(path_spec, slices)
+    contract_digest = _learning_contract_digest(path_spec, slice_map)
+    area_map = {area["area_id"]: area for area in path_spec["areas"]}
+    expected_names = {
+        f"slice_completed.{slice_id}.json"
+        for slice_id in slice_map
+    } | {
+        f"checkpoint_answered.{area_id}.json"
+        for area_id in area_map
+    }
+    events_dir = _contained_child(learning_dir, "events")
+    if events_dir.exists() and not events_dir.is_dir():
+        raise SpecError(f"Learning events path is not a directory: {events_dir}")
+    if events_dir.is_dir():
+        unexpected = sorted(
+            path.name for path in events_dir.glob("*.json") if path.name not in expected_names
+        )
+        if unexpected:
+            raise SpecError(f"Unexpected Learning event files: {unexpected}")
+
+    slice_records: dict[str, dict[str, Any]] = {}
+    checkpoint_records: dict[str, dict[str, Any]] = {}
+    present_keys: set[str] = set()
+    for slice_id, item in slice_map.items():
+        path = _learning_event_path(learning_dir, "slice_completed", slice_id)
+        if path.exists() and not path.is_file():
+            raise SpecError(f"Learning event path is not a file: {path}")
+        if path.is_file():
+            slice_records[slice_id] = _validate_slice_event(
+                path, read_json_object(path), path_spec, item, contract_digest
+            )
+            present_keys.add(f"slice_completed:{slice_id}")
+    for area_id, area in area_map.items():
+        path = _learning_event_path(learning_dir, "checkpoint_answered", area_id)
+        if path.exists() and not path.is_file():
+            raise SpecError(f"Learning event path is not a file: {path}")
+        if path.is_file():
+            checkpoint_records[area_id] = _validate_checkpoint_event(
+                path, read_json_object(path), path_spec, area, contract_digest
+            )
+            present_keys.add(f"checkpoint_answered:{area_id}")
+
+    sequence_keys = [f"{event_type}:{subject_id}" for event_type, subject_id in _learning_sequence(path_spec)]
+    completed_keys: list[str] = []
+    missing_seen = False
+    for key in sequence_keys:
+        if key in present_keys:
+            if missing_seen:
+                raise SpecError(f"Learning events are out of order at {key}")
+            completed_keys.append(key)
+        else:
+            missing_seen = True
+    return slice_records, checkpoint_records, completed_keys
+
+
+def record_slice_completion(
+    learning_dir: Path,
+    path_spec: Mapping[str, Any],
+    slices: Mapping[str, Mapping[str, Any]] | Iterable[Mapping[str, Any]],
+    slice_id: str,
+    request_id: str,
+) -> tuple[dict[str, Any], bool]:
+    slice_id = _identifier(slice_id, "slice_id")
+    request_id = _identifier(request_id, "request_id")
+    slice_map = _slice_map_for_path(path_spec, slices)
+    if slice_id not in slice_map:
+        raise SpecError(f"Unknown slice_id: {slice_id}")
+    slice_records, _, completed_keys = _validated_learning_records(
+        learning_dir, path_spec, slice_map
+    )
+    if completed_keys:
+        validate_choice_label_contract(
+            path_spec, check_future_surfaces=False
+        )
+    else:
+        validate_choice_description_contract(path_spec)
+    path = _learning_event_path(learning_dir, "slice_completed", slice_id)
+    if slice_id in slice_records:
+        return _idempotent_existing(path, request_id=request_id)
+    sequence = [f"{event_type}:{subject_id}" for event_type, subject_id in _learning_sequence(path_spec)]
+    next_key = sequence[len(completed_keys)] if len(completed_keys) < len(sequence) else None
+    if next_key != f"slice_completed:{slice_id}":
+        raise IncompleteLearningError(f"Slice is not the next unlocked node: {slice_id}")
+    completed = set(slice_records)
+    missing = sorted(set(slice_map[slice_id]["prerequisites"]) - completed)
+    if missing:
+        raise IncompleteLearningError(f"Slice prerequisites are incomplete: {missing}")
+    record = {
+        "schema_version": 3,
+        "record_type": "learning_event",
+        "event_type": "slice_completed",
+        "cycle_id": path_spec["cycle_id"],
+        "slice_id": slice_id,
+        "area_id": slice_map[slice_id]["area_id"],
+        "learning_contract_digest": _learning_contract_digest(
+            path_spec, slice_map
+        ),
+        "slice_digest": _slice_digest(slice_map[slice_id]),
+        "request_id": request_id,
+        "completed_at": utc_now(),
+        "mastery_effect": "progress_only",
+    }
+    try:
+        write_json_once(path, record)
+    except FileExistsError:
+        return _idempotent_existing(path, request_id=request_id)
+    return record, True
+
+
+def record_checkpoint_response(
+    learning_dir: Path,
+    path_spec: Mapping[str, Any],
+    area_id: str,
+    selected_option_id: str,
+    displayed_option_order: list[str],
+    request_id: str,
+    *,
+    slices: Mapping[str, Mapping[str, Any]] | Iterable[Mapping[str, Any]],
+) -> tuple[dict[str, Any], bool]:
+    area_id = _identifier(area_id, "area_id")
+    request_id = _identifier(request_id, "request_id")
+    area = next((item for item in path_spec["areas"] if item["area_id"] == area_id), None)
+    if area is None:
+        raise SpecError(f"Unknown learning area: {area_id}")
+    _, checkpoint_records, completed_keys = _validated_learning_records(
+        learning_dir, path_spec, slices
+    )
+    if completed_keys:
+        validate_choice_label_contract(
+            path_spec, check_future_surfaces=False
+        )
+    else:
+        validate_choice_description_contract(path_spec)
+    path = _learning_event_path(learning_dir, "checkpoint_answered", area_id)
+    if area_id in checkpoint_records:
+        return _idempotent_existing(
+            path, request_id=request_id, selected_option_id=selected_option_id
+        )
+    sequence = [f"{event_type}:{subject_id}" for event_type, subject_id in _learning_sequence(path_spec)]
+    next_key = sequence[len(completed_keys)] if len(completed_keys) < len(sequence) else None
+    if next_key != f"checkpoint_answered:{area_id}":
+        raise IncompleteLearningError(
+            f"Checkpoint is not the next unlocked node: {area_id}"
+        )
+    slice_records, _, _ = _validated_learning_records(learning_dir, path_spec, slices)
+    completed = set(slice_records)
+    missing = sorted(set(area["slice_ids"]) - completed)
+    if missing:
+        raise IncompleteLearningError(f"Area slices are incomplete: {missing}")
+    question = area["checkpoint"]
+    slice_map = _slice_map_for_path(path_spec, slices)
+    selected_option_id = _identifier(selected_option_id, "selected_option_id")
+    order = _validate_display_order(question, displayed_option_order)
+    options = {item["id"]: item for item in question["options"]}
+    if selected_option_id not in options:
+        raise SpecError("selected_option_id is not a checkpoint option")
+    selected = options[selected_option_id]
+    record = {
+        "schema_version": 3,
+        "record_type": "learning_event",
+        "event_type": "checkpoint_answered",
+        "cycle_id": path_spec["cycle_id"],
+        "area_id": area_id,
+        "question_id": question["question_id"],
+        "learning_contract_digest": _learning_contract_digest(
+            path_spec, slice_map
+        ),
+        "question_digest": _question_digest(question),
+        "knowledge_kernel_id": question["knowledge_kernel_id"],
+        "concept_id": question["concept_id"],
+        "scenario_id": question["scenario_id"],
+        "scenario_fingerprint": question["scenario_fingerprint"],
+        "question_family": question["question_family"],
+        "displayed_option_order": order,
+        "selected_option_id": selected_option_id,
+        "selected_misconception_tag": selected["misconception_tag"] or None,
+        "correct_option_id": question["correct_option_id"],
+        "is_correct": selected_option_id == question["correct_option_id"],
+        "independence": "feedback_exposed",
+        "feedback_exposed": True,
+        "feedback_timing": "immediate_after_commit",
+        "request_id": request_id,
+        "answered_at": utc_now(),
+    }
+    try:
+        write_json_once(path, record)
+    except FileExistsError:
+        return _idempotent_existing(
+            path, request_id=request_id, selected_option_id=selected_option_id
+        )
+    return record, True
+
+
+def record_learning_event(
+    learning_dir: Path,
+    path_spec: Mapping[str, Any],
+    event_type: str,
+    subject_id: str,
+    request_id: str,
+    *,
+    slices: Mapping[str, Mapping[str, Any]] | Iterable[Mapping[str, Any]] | None = None,
+    selected_option_id: str | None = None,
+    displayed_option_order: list[str] | None = None,
+) -> tuple[dict[str, Any], bool]:
+    if event_type == "slice_completed":
+        if slices is None:
+            raise SpecError("slice completion requires slice files")
+        return record_slice_completion(
+            learning_dir, path_spec, slices, subject_id, request_id
+        )
+    if event_type == "checkpoint_answered":
+        if slices is None:
+            raise SpecError("checkpoint response requires slice files")
+        if selected_option_id is None or displayed_option_order is None:
+            raise SpecError("checkpoint response requires an option and displayed order")
+        return record_checkpoint_response(
+            learning_dir,
+            path_spec,
+            subject_id,
+            selected_option_id,
+            displayed_option_order,
+            request_id,
+            slices=slices,
+        )
+    raise SpecError(f"Unsupported learning event_type: {event_type}")
+
+
+def learning_completion_state(
+    learning_dir: Path,
+    path_spec: Mapping[str, Any],
+    *,
+    slices: Mapping[str, Mapping[str, Any]] | Iterable[Mapping[str, Any]],
+) -> dict[str, Any]:
+    slice_records, checkpoint_records, completed_event_keys = _validated_learning_records(
+        learning_dir, path_spec, slices
+    )
+    completed_slices = set(slice_records)
+    required_slices = {
+        slice_id for area in path_spec["areas"] for slice_id in area["slice_ids"]
+    }
+    missing_slices = sorted(required_slices - completed_slices)
+    completed_checkpoints = set(checkpoint_records)
+    required_areas = {area["area_id"] for area in path_spec["areas"]}
+    missing_checkpoints = sorted(required_areas - completed_checkpoints)
+    sequence_keys = [f"{event_type}:{subject_id}" for event_type, subject_id in _learning_sequence(path_spec)]
+    return {
+        "complete": not missing_slices and not missing_checkpoints,
+        "completed_slice_ids": sorted(completed_slices & required_slices),
+        "missing_slice_ids": missing_slices,
+        "completed_checkpoint_area_ids": sorted(completed_checkpoints),
+        "missing_checkpoint_area_ids": missing_checkpoints,
+        "completed_slices": len(completed_slices & required_slices),
+        "total_slices": len(required_slices),
+        "completed_checkpoints": len(completed_checkpoints),
+        "total_checkpoints": len(required_areas),
+        "completed_event_keys": completed_event_keys,
+        "next_event_key": (
+            sequence_keys[len(completed_event_keys)]
+            if len(completed_event_keys) < len(sequence_keys)
+            else None
+        ),
+    }
+
+
+def ensure_review_ready(
+    learning_dir: Path,
+    path_spec: Mapping[str, Any],
+    *,
+    slices: Mapping[str, Mapping[str, Any]] | Iterable[Mapping[str, Any]],
+) -> dict[str, Any]:
+    state = learning_completion_state(learning_dir, path_spec, slices=slices)
+    if not state["complete"]:
+        raise IncompleteLearningError(
+            "Review is locked until every slice and area checkpoint is complete"
+        )
+    return state
+
+
+def build_learning_report(
+    learning_dir: Path,
+    path_spec: Mapping[str, Any],
+    *,
+    slices: Mapping[str, Mapping[str, Any]] | Iterable[Mapping[str, Any]],
+    require_complete: bool = True,
+    persist: bool = False,
+) -> dict[str, Any]:
+    slice_map = _slice_map_for_path(path_spec, slices)
+    contract_digest = _learning_contract_digest(path_spec, slice_map)
+    state = learning_completion_state(
+        learning_dir, path_spec, slices=slice_map
+    )
+    if require_complete and not state["complete"]:
+        raise IncompleteLearningError(
+            f"Learning is incomplete: slices={state['missing_slice_ids']}, checkpoints={state['missing_checkpoint_area_ids']}"
+        )
+    checkpoint_results: list[dict[str, Any]] = []
+    gaps: list[dict[str, Any]] = []
+    for area in path_spec["areas"]:
+        path = _learning_event_path(
+            learning_dir, "checkpoint_answered", area["area_id"]
+        )
+        if not path.is_file():
+            continue
+        record = _validate_checkpoint_event(
+            path, read_json_object(path), path_spec, area, contract_digest
+        )
+        checkpoint = area["checkpoint"]
+        if record.get("question_digest") != _question_digest(checkpoint):
+            raise SpecError(f"Checkpoint question digest mismatch: {path}")
+        _validate_display_order(checkpoint, record.get("displayed_option_order"))
+        expected = record.get("selected_option_id") == checkpoint["correct_option_id"]
+        if record.get("is_correct") is not expected:
+            raise SpecError(f"Checkpoint correctness mismatch: {path}")
+        result = {
+            "area_id": area["area_id"],
+            "question_id": checkpoint["question_id"],
+            "knowledge_kernel_id": checkpoint["knowledge_kernel_id"],
+            "is_correct": expected,
+            "selected_option_id": record.get("selected_option_id"),
+            "misconception_tag": record.get("selected_misconception_tag"),
+        }
+        checkpoint_results.append(result)
+        if not expected:
+            gaps.append(
+                {
+                    "gap_id": f"learning.{checkpoint['question_id']}",
+                    "source": "learning_checkpoint",
+                    "source_question_id": checkpoint["question_id"],
+                    "area_id": area["area_id"],
+                    "knowledge_kernel_id": checkpoint["knowledge_kernel_id"],
+                    "core_proposition": checkpoint["core_proposition"],
+                    "sources": checkpoint["sources"],
+                    "misconception_tag": record.get("selected_misconception_tag"),
+                }
+            )
+    report = {
+        "schema_version": 3,
+        "report_type": "learning_report",
+        "cycle_id": path_spec["cycle_id"],
+        **state,
+        "checkpoint_results": checkpoint_results,
+        "gaps": gaps,
+        "review_ready": state["complete"],
+        "area_results": [
+            {
+                "area_id": area["area_id"],
+                "completed_slices": len(
+                    set(area["slice_ids"]) & set(state["completed_slice_ids"])
+                ),
+                "total_slices": len(area["slice_ids"]),
+                "checkpoint_complete": area["area_id"]
+                in set(state["completed_checkpoint_area_ids"]),
+                "checkpoint_correct": next(
+                    (
+                        item["is_correct"]
+                        for item in checkpoint_results
+                        if item["area_id"] == area["area_id"]
+                    ),
+                    None,
+                ),
+            }
+            for area in path_spec["areas"]
+        ],
+        "mastery_effect": "learning_progress_only",
+        "generated_at": utc_now(),
+    }
+    if persist:
+        atomic_write_json(_contained_child(learning_dir, "report.json"), report)
+    return report
+
+
+def build_review_report(
+    review_dir: Path,
+    review_spec: Mapping[str, Any],
+    assessment_report: Mapping[str, Any],
+    learning_report: Mapping[str, Any] | None = None,
+    *,
+    require_complete: bool = True,
+    persist: bool = False,
+    now: dt.datetime | None = None,
+) -> dict[str, Any]:
+    responses, missing = _responses_for(
+        review_dir, review_spec, require_complete=require_complete
+    )
+    prior_gaps = _combined_gap_records(assessment_report, learning_report)
+    prior_gap_by_kernel: dict[str, list[dict[str, Any]]] = {}
+    for gap in prior_gaps:
+        prior_gap_by_kernel.setdefault(gap["knowledge_kernel_id"], []).append(gap)
+    primary_review_kernels = {
+        question["primary_kernel_id"] for question in review_spec["questions"]
+    }
+    directly_reviewed_gap_ids = {
+        gap["gap_id"]
+        for gap in prior_gaps
+        if gap["knowledge_kernel_id"] in primary_review_kernels
+    }
+    not_directly_reviewed_gap_ids = {
+        gap["gap_id"] for gap in prior_gaps
+    } - directly_reviewed_gap_ids
+    corrected_gap_ids: set[str] = set()
+    remaining_gap_ids: set[str] = set()
+    new_errors: list[dict[str, Any]] = []
+    reinforced: list[dict[str, Any]] = []
+    integration_results: list[dict[str, Any]] = []
+    question_results: list[dict[str, Any]] = []
+    for question in review_spec["questions"]:
+        response = responses.get(question["question_id"])
+        if response is None:
+            continue
+        primary_gaps = prior_gap_by_kernel.get(question["primary_kernel_id"], [])
+        integrated_gaps = [
+            gap
+            for kernel in question["integrated_kernel_ids"]
+            for gap in prior_gap_by_kernel.get(kernel, [])
+        ]
+        if response["is_correct"]:
+            corrected_gap_ids.update(gap["gap_id"] for gap in primary_gaps)
+            if not primary_gaps:
+                reinforced.append(
+                    {
+                        "question_id": question["question_id"],
+                        "knowledge_kernel_id": question["primary_kernel_id"],
+                        "core_proposition": question["core_proposition"],
+                    }
+                )
+        else:
+            if primary_gaps:
+                remaining_gap_ids.update(gap["gap_id"] for gap in primary_gaps)
+            else:
+                new_errors.append(
+                    {
+                        "question_id": question["question_id"],
+                        "area_id": question["area_id"],
+                        "knowledge_kernel_id": question["primary_kernel_id"],
+                        "core_proposition": question["core_proposition"],
+                        "misconception_tag": response.get("selected_misconception_tag"),
+                    }
+                )
+        question_results.append(
+            {
+                "question_id": question["question_id"],
+                "primary_kernel_id": question["primary_kernel_id"],
+                "integrated_kernel_ids": question["integrated_kernel_ids"],
+                "is_correct": response["is_correct"],
+                "prior_gap_ids": [gap["gap_id"] for gap in primary_gaps],
+                "integrated_gap_ids": [gap["gap_id"] for gap in integrated_gaps],
+            }
+        )
+        if question["integrated_kernel_ids"]:
+            integration_results.append(
+                {
+                    "question_id": question["question_id"],
+                    "primary_kernel_id": question["primary_kernel_id"],
+                    "integrated_kernel_ids": question["integrated_kernel_ids"],
+                    "is_correct": response["is_correct"],
+                }
+            )
+    all_prior_gap_ids = {gap["gap_id"] for gap in prior_gaps}
+    remaining_gap_ids.update(all_prior_gap_ids - corrected_gap_ids)
+    corrected_gap_ids -= remaining_gap_ids
+    answered_in_order = [
+        responses[question["question_id"]]
+        for question in review_spec["questions"]
+        if question["question_id"] in responses
+    ]
+    if answered_in_order:
+        completion_anchor = answered_in_order[-1]["answered_at"]
+        due_base = dt.datetime.fromisoformat(
+            completion_anchor.replace("Z", "+00:00")
+        )
+    else:
+        due_base = now or dt.datetime.now(dt.timezone.utc)
+        completion_anchor = due_base.isoformat()
+    due_date = (due_base.date() + dt.timedelta(days=3)).isoformat()
+    delayed = [
+        {"gap_id": gap_id, "due_date": due_date, "mode": "uncued"}
+        for gap_id in sorted(remaining_gap_ids)
+    ] + [
+        {
+            "gap_id": f"review.{item['question_id']}",
+            "due_date": due_date,
+            "mode": "uncued",
+        }
+        for item in new_errors
+    ]
+    report = {
+        "schema_version": 3,
+        "report_type": "review_report",
+        "cycle_id": review_spec["cycle_id"],
+        "complete": not missing,
+        "answered": len(responses),
+        "total": len(review_spec["questions"]),
+        "question_results": question_results,
+        "directly_reviewed_gap_ids": sorted(directly_reviewed_gap_ids),
+        "not_directly_reviewed_gap_ids": sorted(not_directly_reviewed_gap_ids),
+        "corrected_gap_ids": sorted(corrected_gap_ids),
+        "remaining_gap_ids": sorted(remaining_gap_ids),
+        "new_errors": new_errors,
+        "reinforced_concepts": reinforced,
+        "integration_results": integration_results,
+        "delayed_review": delayed,
+        "missing_question_ids": missing,
+        "completion_anchor": completion_anchor,
+        "generated_at": utc_now(),
+    }
+    if persist:
+        atomic_write_json(_contained_child(review_dir, "report.json"), report)
+    return report
+
+
+__all__ = [
+    "ConflictError",
+    "IncompleteLearningError",
+    "IncompletePhaseError",
+    "PhaseLock",
+    "SpecError",
+    "atomic_write_json",
+    "build_assessment_report",
+    "build_learning_report",
+    "build_review_report",
+    "choice_description_is_safe",
+    "choice_description_leaks_answer",
+    "clamp",
+    "ensure_batch_manifest",
+    "ensure_review_ready",
+    "learning_completion_state",
+    "load_cycle",
+    "read_json_object",
+    "record_checkpoint_response",
+    "record_learning_event",
+    "record_response",
+    "record_slice_completion",
+    "response_completion_state",
+    "resolve_cycle",
+    "scenario_fingerprint",
+    "validate_assessment_spec",
+    "validate_batch_manifest",
+    "validate_choice_description_contract",
+    "validate_choice_label_contract",
+    "validate_visible_context_contract",
+    "validate_cycle",
+    "validate_learning_path",
+    "validate_learning_slice",
+    "validate_review_spec",
+    "write_json_once",
+]

--- a/weeks/2026/2026-w35-mastery-loop/completed/mastery-loop/tests/test_mastery_loop.py
+++ b/weeks/2026/2026-w35-mastery-loop/completed/mastery-loop/tests/test_mastery_loop.py
@@ -1,0 +1,332 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import re
+import subprocess
+import sys
+import tempfile
+import threading
+import unittest
+import urllib.request
+from http.server import ThreadingHTTPServer
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def load_module(name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+ui = load_module("mastery_click_ui", ROOT / "scripts" / "click_choice_ui.py")
+
+
+def knowledge_spec(question_id: str = "audit-q1", mode: str = "audit") -> dict:
+    data = {
+        "schema_version": 2,
+        "question_id": question_id,
+        "kind": "knowledge",
+        "mode": mode,
+        "concept_id": "handoff-contract",
+        "knowledge_kernel_id": "handoff.explicit-contract",
+        "scenario_id": "youtube-facebook-pipeline",
+        "core_proposition": "A handoff requires explicit inputs, outputs, validation, and failure behavior.",
+        "scenario_context": "A workflow turns YouTube subtitles and a thumbnail into a Facebook post.",
+        "question_family": "application",
+        "title": "交接缺少影片 ID",
+        "prompt": "字幕已回傳，但來源影片 ID 缺失。下一個代理應該怎麼做？",
+        "options": [
+            {
+                "id": "stop-and-validate",
+                "label": "停止並要求補齊必要欄位",
+                "description": "先驗證交接契約。",
+                "explanation": "影片 ID 是內容溯源與縮圖取得的必要欄位；缺少時停止可避免錯誤跨代理擴散。",
+                "misconception_tag": "",
+            },
+            {
+                "id": "guess-id",
+                "label": "從標題猜測影片 ID",
+                "description": "先讓流程繼續。",
+                "explanation": "標題無法唯一定位影片，猜測會破壞溯源，也可能擷取到錯誤圖片。",
+                "misconception_tag": "implicit-handoff-data",
+            },
+            {
+                "id": "skip-image",
+                "label": "省略圖片直接發布文字",
+                "description": "避免流程阻塞。",
+                "explanation": "驗收條件要求文字與縮圖同時交付，省略圖片會形成不完整成果。",
+                "misconception_tag": "partial-output-is-complete",
+            },
+        ],
+        "correct_option_ids": ["stop-and-validate"],
+    }
+    if mode == "review":
+        data["review_of"] = "audit-q1"
+        data["question_family"] = "sequence"
+        data["prompt"] = "同一條工作流發現來源 ID 缺失，請選出可靠的處理順序。"
+        data["options"] = [
+            {
+                "id": "new-guess-sequence",
+                "label": "推測來源、產生縮圖、最後驗證",
+                "description": "先追求流程完成。",
+                "explanation": "驗證被放到最後，錯誤資料會先流入後續階段。",
+                "misconception_tag": "implicit-handoff-data",
+            },
+            {
+                "id": "new-validate-sequence",
+                "label": "停止交接、補齊來源、驗證後續跑",
+                "description": "把契約驗證放在交接邊界。",
+                "explanation": "先阻止不完整輸出離開交接邊界，再補值與驗證，能保持溯源和縮圖正確性。",
+                "misconception_tag": "",
+            },
+            {
+                "id": "new-partial-sequence",
+                "label": "先發布文字、補齊來源、再補圖片",
+                "description": "把圖片延後處理。",
+                "explanation": "發布發生在完整驗收之前，最終結果會在一段時間內違反交付契約。",
+                "misconception_tag": "partial-output-is-complete",
+            },
+        ]
+        data["correct_option_ids"] = ["new-validate-sequence"]
+    return data
+
+
+class SpecTests(unittest.TestCase):
+    def test_version_one_remains_readable(self):
+        old = {
+            "question_id": "old-q",
+            "kind": "knowledge",
+            "mode": "audit",
+            "title": "Legacy",
+            "prompt": "Choose.",
+            "options": [
+                {"id": "one", "label": "One"},
+                {"id": "two", "label": "Two"},
+                {"id": "three", "label": "Three"},
+            ],
+            "correct_option_ids": ["one"],
+        }
+        self.assertEqual(ui.validate_spec(old)["schema_version"], 1)
+
+    def test_version_two_requires_every_explanation(self):
+        data = knowledge_spec()
+        del data["options"][1]["explanation"]
+        with self.assertRaises(ui.SpecError):
+            ui.validate_spec(data)
+
+    def test_unknown_mode_is_rejected(self):
+        data = knowledge_spec()
+        data["mode"] = "retired-mode"
+        with self.assertRaises(ui.SpecError):
+            ui.validate_spec(data)
+
+    def test_review_preserves_kernel_but_changes_surface(self):
+        with tempfile.TemporaryDirectory() as directory:
+            workspace = Path(directory)
+            (workspace / "choice-sessions").mkdir()
+            (workspace / "review-records").mkdir()
+            source = ui.validate_spec(knowledge_spec())
+            selected = source["options"][1]
+            correct = source["options"][0]
+            record = ui.build_review_record(source, selected, correct)
+            (workspace / "review-records" / "audit-q1.json").write_text(
+                json.dumps(record, ensure_ascii=False), encoding="utf-8"
+            )
+            path = workspace / "choice-sessions" / "review-q1.json"
+            path.write_text(
+                json.dumps(knowledge_spec("review-q1", "review"), ensure_ascii=False),
+                encoding="utf-8",
+            )
+            _, loaded = ui.load_spec(workspace, str(path))
+            self.assertEqual(loaded["mode"], "review")
+
+    def test_review_rejects_repeated_family(self):
+        with tempfile.TemporaryDirectory() as directory:
+            workspace = Path(directory)
+            (workspace / "choice-sessions").mkdir()
+            (workspace / "review-records").mkdir()
+            source = ui.validate_spec(knowledge_spec())
+            record = ui.build_review_record(
+                source, source["options"][1], source["options"][0]
+            )
+            (workspace / "review-records" / "audit-q1.json").write_text(
+                json.dumps(record, ensure_ascii=False), encoding="utf-8"
+            )
+            repeated = knowledge_spec("review-q1", "review")
+            repeated["question_family"] = "application"
+            path = workspace / "choice-sessions" / "review-q1.json"
+            path.write_text(json.dumps(repeated, ensure_ascii=False), encoding="utf-8")
+            with self.assertRaises(ui.SpecError):
+                ui.load_spec(workspace, str(path))
+
+    def test_review_rejects_any_reused_option_label(self):
+        with tempfile.TemporaryDirectory() as directory:
+            workspace = Path(directory)
+            (workspace / "choice-sessions").mkdir()
+            (workspace / "review-records").mkdir()
+            source = ui.validate_spec(knowledge_spec())
+            record = ui.build_review_record(
+                source, source["options"][1], source["options"][0]
+            )
+            (workspace / "review-records" / "audit-q1.json").write_text(
+                json.dumps(record, ensure_ascii=False), encoding="utf-8"
+            )
+            reused = knowledge_spec("review-q1", "review")
+            reused["options"][0]["label"] = source["options"][1]["label"]
+            path = workspace / "choice-sessions" / "review-q1.json"
+            path.write_text(json.dumps(reused, ensure_ascii=False), encoding="utf-8")
+            with self.assertRaises(ui.SpecError):
+                ui.load_spec(workspace, str(path))
+
+    def test_answer_persists_conservative_evidence_context(self):
+        audit = ui.validate_spec(knowledge_spec())
+        audit_answer = ui.build_answer(audit, audit["options"][0])
+        self.assertEqual(audit_answer["independence"], "independent")
+        self.assertFalse(audit_answer["feedback_exposed"])
+        self.assertEqual(audit_answer["feedback_timing"], "immediate_after_commit")
+
+        review = ui.validate_spec(knowledge_spec("review-q1", "review"))
+        review_answer = ui.build_answer(review, review["options"][1])
+        self.assertEqual(review_answer["independence"], "feedback_exposed")
+        self.assertTrue(review_answer["feedback_exposed"])
+
+
+class RenderTests(unittest.TestCase):
+    def setUp(self):
+        self.spec = ui.validate_spec(knowledge_spec())
+
+    def test_initial_page_hides_answer_data(self):
+        browser_options = {
+            "opaque-a": self.spec["options"][0],
+            "opaque-b": self.spec["options"][1],
+            "opaque-c": self.spec["options"][2],
+        }
+        page = ui.render_question(self.spec, "csrf-value", browser_options)
+        self.assertNotIn("stop-and-validate", page)
+        self.assertNotIn("implicit-handoff-data", page)
+        self.assertNotIn(self.spec["options"][0]["explanation"], page)
+        self.assertIn("opaque-a", page)
+        self.assertIn("Created by Winston", page)
+        self.assertIn("<script>(()=>{", page)
+
+    def test_correct_page_explains_and_can_close(self):
+        page = ui.render_feedback(self.spec, "stop-and-validate", "csrf")
+        self.assertIn("回答正確", page)
+        self.assertIn(self.spec["options"][0]["explanation"], page)
+        self.assertIn("可以關閉此頁", page)
+        self.assertNotIn("記錄這個錯誤", page)
+
+    def test_wrong_page_explains_both_and_gates_close_copy(self):
+        page = ui.render_feedback(self.spec, "guess-id", "csrf")
+        self.assertIn(self.spec["options"][1]["explanation"], page)
+        self.assertIn(self.spec["options"][0]["explanation"], page)
+        self.assertIn("記錄這個錯誤", page)
+        self.assertNotIn("可以關閉此頁", page)
+
+    def test_recorded_page_has_close_copy_and_footer(self):
+        page = ui.render_review_recorded(self.spec)
+        self.assertIn("錯誤已記錄", page)
+        self.assertIn("可以關閉此頁", page)
+        self.assertIn("Created by Winston", page)
+
+
+class HttpFlowTests(unittest.TestCase):
+    def run_server(self, spec: dict, workspace: Path):
+        answer_path = ui.answer_path_for(workspace, spec["question_id"])
+        review_path = ui.review_record_path_for(workspace, spec["question_id"])
+        server = ThreadingHTTPServer(
+            ("127.0.0.1", 0), ui.make_handler(spec, answer_path, review_path, "csrf")
+        )
+        thread = threading.Thread(target=server.serve_forever, daemon=True)
+        thread.start()
+        return server, thread, answer_path, review_path
+
+    def get(self, url: str):
+        with urllib.request.urlopen(url, timeout=3) as response:
+            return response.read().decode("utf-8"), response.headers
+
+    def post(self, url: str, payload: dict):
+        request = urllib.request.Request(
+            url,
+            data=json.dumps(payload).encode("utf-8"),
+            headers={"Content-Type": "application/json", "X-Choice-Token": "csrf"},
+            method="POST",
+        )
+        with urllib.request.urlopen(request, timeout=3) as response:
+            return response.read().decode("utf-8"), response.headers
+
+    def test_correct_answer_returns_feedback_and_stops(self):
+        with tempfile.TemporaryDirectory() as directory:
+            workspace = Path(directory)
+            spec = ui.validate_spec(knowledge_spec("correct-flow"))
+            server, thread, answer_path, _ = self.run_server(spec, workspace)
+            url = f"http://127.0.0.1:{server.server_address[1]}/"
+            page, headers = self.get(url)
+            tokens = re.findall(r'data-option-token="([^"]+)"', page)
+            self.assertIn("frame-ancestors 'none'", headers["Content-Security-Policy"])
+            feedback, _ = self.post(url + "answer", {"option_token": tokens[0]})
+            self.assertIn("回答正確", feedback)
+            thread.join(timeout=3)
+            server.server_close()
+            self.assertFalse(thread.is_alive())
+            self.assertTrue(answer_path.exists())
+
+    def test_wrong_answer_requires_record_then_stops(self):
+        with tempfile.TemporaryDirectory() as directory:
+            workspace = Path(directory)
+            spec = ui.validate_spec(knowledge_spec("wrong-flow"))
+            server, thread, answer_path, review_path = self.run_server(spec, workspace)
+            url = f"http://127.0.0.1:{server.server_address[1]}/"
+            page, _ = self.get(url)
+            tokens = re.findall(r'data-option-token="([^"]+)"', page)
+            feedback, _ = self.post(url + "answer", {"option_token": tokens[1]})
+            self.assertIn("記錄這個錯誤", feedback)
+            self.assertTrue(answer_path.exists())
+            self.assertFalse(review_path.exists())
+            self.assertTrue(thread.is_alive())
+            complete, _ = self.post(url + "record", {})
+            self.assertIn("錯誤已記錄", complete)
+            thread.join(timeout=3)
+            server.server_close()
+            self.assertFalse(thread.is_alive())
+            self.assertTrue(review_path.exists())
+            record = json.loads(review_path.read_text(encoding="utf-8"))
+            self.assertEqual(record["status"], "due")
+            self.assertEqual(record["selected_option"]["id"], "guess-id")
+
+
+class WorkspaceInitTests(unittest.TestCase):
+    def test_default_cycle_and_no_overwrite(self):
+        script = ROOT / "scripts" / "init_workspace.py"
+        with tempfile.TemporaryDirectory() as directory:
+            command = [
+                sys.executable,
+                str(script),
+                "--path",
+                directory,
+                "--topic",
+                "Agent Workflow",
+                "--why",
+                "Deliver an end-to-end workflow",
+            ]
+            first = subprocess.run(command, check=True, capture_output=True, text=True)
+            self.assertIn("CREATE MASTERY.md", first.stdout)
+            root = Path(directory)
+            self.assertTrue((root / "review-records").is_dir())
+            self.assertTrue((root / "mastery-sessions").is_dir())
+            mastery = (root / "MASTERY.md").read_text(encoding="utf-8")
+            self.assertIn("Mode: audit", mastery)
+            (root / "MISSION.md").write_text("keep me", encoding="utf-8")
+            second = subprocess.run(command, check=True, capture_output=True, text=True)
+            self.assertIn("SKIP MISSION.md", second.stdout)
+            self.assertEqual((root / "MISSION.md").read_text(encoding="utf-8"), "keep me")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/weeks/2026/2026-w35-mastery-loop/completed/mastery-loop/tests/test_mastery_session_ui.py
+++ b/weeks/2026/2026-w35-mastery-loop/completed/mastery-loop/tests/test_mastery_session_ui.py
@@ -1,0 +1,1670 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import threading
+import unittest
+import urllib.error
+import urllib.request
+from http.server import ThreadingHTTPServer
+from pathlib import Path
+
+from test_session_core import assessment_spec, cycle_spec, learning_fixture, review_spec
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def load_module(name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+ui = load_module("mastery_session_ui_v3", ROOT / "scripts" / "mastery_session_ui.py")
+
+
+def write_assessment_workspace(root: Path) -> tuple[Path, ui.SessionBundle]:
+    cycle_dir = root / "mastery-sessions" / "agent-workflow-cycle"
+    (cycle_dir / "assessment" / "responses").mkdir(parents=True)
+    (cycle_dir / "cycle.json").write_text(
+        json.dumps(cycle_spec(), ensure_ascii=False), encoding="utf-8"
+    )
+    (cycle_dir / "assessment" / "spec.json").write_text(
+        json.dumps(assessment_spec(), ensure_ascii=False), encoding="utf-8"
+    )
+    bundle = ui.load_phase_bundle(
+        root, "mastery-sessions/agent-workflow-cycle", "assessment"
+    )
+    return cycle_dir, bundle
+
+
+def apply_unsafe_choice_case(raw: dict, case: str) -> str:
+    question = raw["questions"][0]
+    option = question["options"][0]
+    if case == "future-prompt":
+        description = raw["questions"][1]["prompt"]
+    elif case == "short-future-prompt":
+        raw["questions"][1]["prompt"] = "Pick now?"
+        description = "Boundary note: Pick now? Later context remains separate."
+    elif case == "future-correct-label":
+        future = raw["questions"][1]
+        description = next(
+            item["label"]
+            for item in future["options"]
+            if item["id"] == future["correct_option_id"]
+        )
+    elif case == "stable-option-id":
+        description = (
+            f'Internal option key: {question["correct_option_id"]}; tracking only.'
+        )
+    elif case == "embedded-stable-option-id":
+        description = (
+            f'Internal marker trace-{question["correct_option_id"]}-copy only.'
+        )
+    elif case == "plain-stable-option-id":
+        option["id"] = "correctanswer"
+        question["correct_option_id"] = "correctanswer"
+        description = "Internal option key correctanswer for workflow tracking."
+    elif case == "prompt-hidden-explanation":
+        correct = next(
+            item
+            for item in question["options"]
+            if item["id"] == question["correct_option_id"]
+        )
+        question["prompt"] = correct["explanation"]
+        description = option["description"]
+    elif case == "prompt-stable-option-id":
+        question["prompt"] = (
+            f'Use internal option key {question["correct_option_id"]} before continuing.'
+        )
+        description = option["description"]
+    elif case == "prompt-correct-position":
+        question["prompt"] = "The first option is the correct answer."
+        description = option["description"]
+    elif case == "prompt-correct-label":
+        correct = next(
+            item
+            for item in question["options"]
+            if item["id"] == question["correct_option_id"]
+        )
+        question["prompt"] = f'Choose "{correct["label"]}".'
+        description = option["description"]
+    elif case == "prompt-future-wrong-explanation":
+        future = raw["questions"][1]
+        wrong = next(
+            item
+            for item in future["options"]
+            if item["id"] != future["correct_option_id"]
+        )
+        question["prompt"] = wrong["explanation"]
+        description = option["description"]
+    elif case == "prompt-future-wrong-label":
+        future = raw["questions"][1]
+        wrong = next(
+            item
+            for item in future["options"]
+            if item["id"] != future["correct_option_id"]
+        )
+        question["prompt"] = f'Avoid "{wrong["label"]}"; it fails the contract.'
+        description = option["description"]
+    elif case == "prompt-current-wrong-label":
+        wrong = next(
+            item
+            for item in question["options"]
+            if item["id"] != question["correct_option_id"]
+        )
+        question["prompt"] = f'Avoid "{wrong["label"]}"; it fails the contract.'
+        description = option["description"]
+    elif case == "description-other-option-label":
+        correct = next(
+            item
+            for item in question["options"]
+            if item["id"] == question["correct_option_id"]
+        )
+        question["options"][1]["description"] = (
+            f'Unlike "{correct["label"]}", this leaves evidence unresolved.'
+        )
+        description = question["options"][1]["description"]
+    elif case == "prompt-option-letter":
+        question["prompt"] = "Option A is correct."
+        description = option["description"]
+    elif case == "prompt-option-number":
+        question["prompt"] = "Option 1 is the correct answer."
+        description = option["description"]
+    elif case == "prompt-option-chinese-letter":
+        question["prompt"] = "選項 A 是正確答案。"
+        description = option["description"]
+    elif case == "prompt-first-full-credit":
+        question["prompt"] = (
+            "The response shown first earns full credit; explain why."
+        )
+        description = option["description"]
+    elif case == "prompt-top-answer":
+        question["prompt"] = "The top response is the answer; explain why."
+        description = option["description"]
+    elif case == "scenario-option-full-credit":
+        question["scenario_context"] = (
+            "The evaluator marks option A as full credit."
+        )
+        description = option["description"]
+    elif case == "intro-future-correct-label":
+        future = raw["questions"][1]
+        correct = next(
+            item
+            for item in future["options"]
+            if item["id"] == future["correct_option_id"]
+        )
+        raw["instructions"] = (
+            f'Answer key for the next item: {correct["label"]}'
+        )
+        description = option["description"]
+    elif case == "intro-stable-option-id":
+        raw["instructions"] = (
+            f'Internal answer key: {raw["questions"][1]["correct_option_id"]}'
+        )
+        description = option["description"]
+    elif case == "short-correct-id-label":
+        for item, option_id in zip(question["options"], ("win", "lose", "bad")):
+            item["id"] = option_id
+        question["correct_option_id"] = "win"
+        question["options"][0]["label"] = "win - validate the contract"
+        description = question["options"][0]["description"]
+    elif case == "short-wrong-id-label":
+        question["options"][1]["id"] = "bad"
+        question["options"][1]["label"] = "bad - continue with partial state"
+        description = option["description"]
+    elif case == "short-stopword-id-suffix-context":
+        for item, option_id in zip(question["options"], ("a", "b", "c")):
+            item["id"] = option_id
+        question["correct_option_id"] = "a"
+        question["options"][0]["description"] = (
+            "a is the internal option key for workflow tracking."
+        )
+        description = question["options"][0]["description"]
+    elif case == "prompt-equals-correct-label":
+        correct = next(
+            item
+            for item in question["options"]
+            if item["id"] == question["correct_option_id"]
+        )
+        question["prompt"] = correct["label"]
+        description = option["description"]
+    elif case == "prompt-contains-correct-label":
+        correct = next(
+            item
+            for item in question["options"]
+            if item["id"] == question["correct_option_id"]
+        )
+        question["prompt"] = (
+            f'Proceed with "{correct["label"]}" before any side effect.'
+        )
+        description = option["description"]
+    elif case == "prompt-short-correct-label":
+        correct = next(
+            item
+            for item in question["options"]
+            if item["id"] == question["correct_option_id"]
+        )
+        correct["label"] = "Approve"
+        question["prompt"] = "Required next action: Approve."
+        description = option["description"]
+    elif case == "repeated-prompt-correct-label":
+        future = raw["questions"][3]
+        correct = next(
+            item
+            for item in future["options"]
+            if item["id"] == future["correct_option_id"]
+        )
+        for item in raw["questions"][:4]:
+            item["prompt"] = correct["label"]
+        description = option["description"]
+    elif case == "description-own-label-positive":
+        option["description"] = (
+            f'Required next action: {option["label"]}; '
+            "downstream reporting remains separate."
+        )
+        description = option["description"]
+    elif case == "description-own-label-negative":
+        option["description"] = (
+            f'Avoid {option["label"]}; the contract boundary remains unresolved.'
+        )
+        description = option["description"]
+    elif case == "description-short-own-label-negative":
+        option["label"] = "Run"
+        option["description"] = (
+            "Avoid Run; the contract boundary remains unresolved."
+        )
+        description = option["description"]
+    elif case == "description-cjk-own-label-negative":
+        option["label"] = "停"
+        option["description"] = "不要選停；仍缺少必要條件。"
+        description = option["description"]
+    elif case == "zero-width-stable-id":
+        option["description"] = (
+            "Internal key a0-\u200bcorrect remains outside the learner surface."
+        )
+        description = option["description"]
+    elif case == "zero-width-future-correct-label":
+        future = raw["questions"][1]
+        correct = next(
+            item
+            for item in future["options"]
+            if item["id"] == future["correct_option_id"]
+        )
+        disguised = correct["label"][:3] + "\u200b" + correct["label"][3:]
+        option["description"] = (
+            f'Avoid {disguised} before approval; the boundary remains open.'
+        )
+        description = option["description"]
+    elif case == "label-future-correct":
+        future = raw["questions"][1]
+        option["label"] = next(
+            item["label"]
+            for item in future["options"]
+            if item["id"] == future["correct_option_id"]
+        )
+        description = option["description"]
+    else:
+        description = case
+    option["description"] = description
+    return description
+
+
+def write_completed_assessment(
+    cycle_dir: Path, *, wrong_indices: set[int] | None = None
+) -> tuple[dict, dict]:
+    wrong_indices = wrong_indices or set()
+    (cycle_dir / "assessment" / "responses").mkdir(parents=True, exist_ok=True)
+    raw = assessment_spec()
+    normalized = ui.core.validate_assessment_spec(
+        raw, ui.core.validate_cycle(cycle_spec())
+    )
+    (cycle_dir / "assessment" / "spec.json").write_text(
+        json.dumps(raw, ensure_ascii=False), encoding="utf-8"
+    )
+    for index, question in enumerate(normalized["questions"]):
+        selected = question["correct_option_id"]
+        if index in wrong_indices:
+            selected = next(
+                option["id"]
+                for option in question["options"]
+                if option["id"] != question["correct_option_id"]
+            )
+        ui.core.record_response(
+            cycle_dir / "assessment",
+            normalized,
+            question["question_id"],
+            selected,
+            [option["id"] for option in question["options"]],
+            f"assessment-fixture-{index}",
+        )
+    report = ui.core.build_assessment_report(
+        cycle_dir / "assessment", normalized, persist=True
+    )
+    return normalized, report
+
+
+def write_learning_workspace(root: Path) -> tuple[Path, ui.SessionBundle]:
+    cycle_dir = root / "mastery-sessions" / "agent-workflow-cycle"
+    (cycle_dir / "learning" / "slices").mkdir(parents=True)
+    (cycle_dir / "learning" / "events").mkdir(parents=True)
+    (cycle_dir / "cycle.json").write_text(
+        json.dumps(cycle_spec(), ensure_ascii=False), encoding="utf-8"
+    )
+    write_completed_assessment(cycle_dir)
+    path_spec, slices = learning_fixture()
+    (cycle_dir / "learning" / "path.json").write_text(
+        json.dumps(path_spec, ensure_ascii=False), encoding="utf-8"
+    )
+    for slice_id, item in slices.items():
+        (cycle_dir / "learning" / "slices" / f"{slice_id}.json").write_text(
+            json.dumps(item, ensure_ascii=False), encoding="utf-8"
+        )
+    bundle = ui.load_phase_bundle(
+        root, "mastery-sessions/agent-workflow-cycle", "learning"
+    )
+    return cycle_dir, bundle
+
+
+def write_review_workspace(root: Path) -> tuple[Path, ui.SessionBundle]:
+    cycle_dir = root / "mastery-sessions" / "agent-workflow-cycle"
+    for path in (
+        cycle_dir / "assessment" / "responses",
+        cycle_dir / "learning" / "slices",
+        cycle_dir / "learning" / "events",
+        cycle_dir / "review" / "responses",
+    ):
+        path.mkdir(parents=True)
+    (cycle_dir / "cycle.json").write_text(
+        json.dumps(cycle_spec(), ensure_ascii=False), encoding="utf-8"
+    )
+    assessment, assessment_report = write_completed_assessment(
+        cycle_dir, wrong_indices=set(range(5))
+    )
+    gaps_by_area = {
+        area: [gap for gap in assessment_report["gaps"] if gap["area_id"] == area]
+        for area in ("contracts", "recovery", "evidence")
+    }
+    counts = {area: 5 + len(gaps) for area, gaps in gaps_by_area.items()}
+    path_spec, slices = learning_fixture(counts)
+    questions_by_area = {
+        area: [question for question in assessment["questions"] if question["area_id"] == area]
+        for area in gaps_by_area
+    }
+    for area in gaps_by_area:
+        area_slices = [slices[slice_id] for slice_id in next(
+            item["slice_ids"] for item in path_spec["areas"] if item["area_id"] == area
+        )]
+        for index, gap in enumerate(gaps_by_area[area]):
+            area_slices[index]["addresses_gap_ids"].append(gap["gap_id"])
+        for index, question in enumerate(questions_by_area[area]):
+            links = area_slices[index % len(area_slices)]["assessment_question_ids"]
+            if question["question_id"] not in links:
+                links.append(question["question_id"])
+    (cycle_dir / "learning" / "path.json").write_text(
+        json.dumps(path_spec, ensure_ascii=False), encoding="utf-8"
+    )
+    for slice_id, item in slices.items():
+        (cycle_dir / "learning" / "slices" / f"{slice_id}.json").write_text(
+            json.dumps(item, ensure_ascii=False), encoding="utf-8"
+        )
+    normalized_path = ui.core.validate_learning_path(
+        path_spec,
+        ui.core.validate_cycle(cycle_spec()),
+        slices=slices,
+        assessment_report=assessment_report,
+        assessment_spec=assessment,
+    )
+    for area in path_spec["areas"]:
+        for slice_id in area["slice_ids"]:
+            ui.core.record_slice_completion(
+                cycle_dir / "learning",
+                normalized_path,
+                slices,
+                slice_id,
+                f"slice-fixture-{slice_id}",
+            )
+        checkpoint = area["checkpoint"]
+        ui.core.record_checkpoint_response(
+            cycle_dir / "learning",
+            normalized_path,
+            area["area_id"],
+            checkpoint["correct_option_id"],
+            [option["id"] for option in checkpoint["options"]],
+            f"checkpoint-fixture-{area['area_id']}",
+            slices=slices,
+        )
+    ui.core.build_learning_report(
+        cycle_dir / "learning", normalized_path, slices=slices, persist=True
+    )
+    (cycle_dir / "review" / "spec.json").write_text(
+        json.dumps(review_spec(), ensure_ascii=False), encoding="utf-8"
+    )
+    bundle = ui.load_phase_bundle(
+        root, "mastery-sessions/agent-workflow-cycle", "review"
+    )
+    return cycle_dir, bundle
+
+
+class AssessmentUiTests(unittest.TestCase):
+    def test_start_seals_the_complete_batch_against_future_question_changes(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            cycle_dir, bundle = write_assessment_workspace(root)
+            runtime = ui.SessionRuntime(bundle)
+            runtime.start({"request_id": "seal-batch-start"})
+            self.assertTrue((cycle_dir / "assessment" / "batch-manifest.json").is_file())
+
+            changed = assessment_spec()
+            changed["questions"][1]["prompt"] = "A changed future prompt."
+            (cycle_dir / "assessment" / "spec.json").write_text(
+                json.dumps(changed, ensure_ascii=False), encoding="utf-8"
+            )
+            with self.assertRaises(ui.core.SpecError):
+                ui.load_phase_bundle(
+                    root, "mastery-sessions/agent-workflow-cycle", "assessment"
+                )
+
+    def test_start_seals_confirmed_mission_scope_and_area_semantics(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            cycle_dir, bundle = write_assessment_workspace(root)
+            runtime = ui.SessionRuntime(bundle)
+            runtime.start({"request_id": "seal-cycle-contract"})
+
+            changed_cycle = cycle_spec()
+            changed_cycle["mission"]["ultimate_outcome"] = "A different outcome"
+            changed_cycle["knowledge_scope"]["direction"] = "A different scope"
+            changed_cycle["areas"][0]["title"] = "A reinterpreted area"
+            (cycle_dir / "cycle.json").write_text(
+                json.dumps(changed_cycle, ensure_ascii=False), encoding="utf-8"
+            )
+
+            with self.assertRaises(ui.core.SpecError):
+                ui.load_phase_bundle(
+                    root, "mastery-sessions/agent-workflow-cycle", "assessment"
+                )
+
+    def test_intro_has_scope_distribution_and_footer(self):
+        with tempfile.TemporaryDirectory() as directory:
+            _, bundle = write_assessment_workspace(Path(directory))
+            runtime = ui.SessionRuntime(bundle)
+            page = runtime.render()
+            self.assertIn("知識範圍", page)
+            self.assertIn("12 題", page)
+            self.assertIn("3 個主要領域", page)
+            self.assertIn("Contracts · 4 題", page)
+            self.assertIn("Benchmark：已驗證", page)
+            self.assertIn("Created by Winston", page)
+            self.assertIn("lang=\"zh-Hant\"", page)
+            self.assertIn("確認範圍並開始", page)
+            self.assertIn("調整範圍", page)
+            self.assertIn("暫停", page)
+
+    def test_intro_rejects_answer_material_in_cycle_scope(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            cycle_dir = root / "mastery-sessions" / "agent-workflow-cycle"
+            (cycle_dir / "assessment" / "responses").mkdir(parents=True)
+            raw_spec = assessment_spec()
+            first = raw_spec["questions"][0]
+            correct = next(
+                item
+                for item in first["options"]
+                if item["id"] == first["correct_option_id"]
+            )
+            raw_cycle = cycle_spec()
+            raw_cycle["knowledge_scope"]["includes"][0] = (
+                f'Correct: {correct["label"]}'
+            )
+            (cycle_dir / "cycle.json").write_text(
+                json.dumps(raw_cycle, ensure_ascii=False), encoding="utf-8"
+            )
+            (cycle_dir / "assessment" / "spec.json").write_text(
+                json.dumps(raw_spec, ensure_ascii=False), encoding="utf-8"
+            )
+            bundle = ui.load_phase_bundle(
+                root, "mastery-sessions/agent-workflow-cycle", "assessment"
+            )
+            with self.assertRaises(ui.core.SpecError):
+                ui._validate_phase_state(bundle)
+            with self.assertRaises(ui.core.SpecError):
+                ui.SessionRuntime(bundle).render()
+
+    def test_intro_allows_plain_scope_term_that_is_also_an_option(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            cycle_dir = root / "mastery-sessions" / "agent-workflow-cycle"
+            (cycle_dir / "assessment" / "responses").mkdir(parents=True)
+            raw_cycle = cycle_spec()
+            raw_cycle["knowledge_scope"]["includes"][0] = (
+                "The assessment includes the idempotency concept and recovery evidence."
+            )
+            raw_spec = assessment_spec()
+            raw_spec["questions"][0]["options"][0]["label"] = (
+                "idempotency concept"
+            )
+            raw_spec["questions"][0]["title"] = "Contracts"
+            (cycle_dir / "cycle.json").write_text(
+                json.dumps(raw_cycle, ensure_ascii=False), encoding="utf-8"
+            )
+            (cycle_dir / "assessment" / "spec.json").write_text(
+                json.dumps(raw_spec, ensure_ascii=False), encoding="utf-8"
+            )
+            bundle = ui.load_phase_bundle(
+                root, "mastery-sessions/agent-workflow-cycle", "assessment"
+            )
+            state = ui._validate_phase_state(bundle)
+            self.assertFalse(state["complete"])
+            self.assertIn("idempotency", ui.SessionRuntime(bundle).render())
+
+    def test_intro_rejects_visible_field_equal_to_correct_label(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            cycle_dir = root / "mastery-sessions" / "agent-workflow-cycle"
+            (cycle_dir / "assessment" / "responses").mkdir(parents=True)
+            raw_cycle = cycle_spec()
+            raw_cycle["mission"]["ultimate_outcome"] = "Approve"
+            raw_spec = assessment_spec()
+            first = raw_spec["questions"][0]
+            correct = next(
+                item
+                for item in first["options"]
+                if item["id"] == first["correct_option_id"]
+            )
+            correct["label"] = "Approve"
+            (cycle_dir / "cycle.json").write_text(
+                json.dumps(raw_cycle, ensure_ascii=False), encoding="utf-8"
+            )
+            (cycle_dir / "assessment" / "spec.json").write_text(
+                json.dumps(raw_spec, ensure_ascii=False), encoding="utf-8"
+            )
+            bundle = ui.load_phase_bundle(
+                root, "mastery-sessions/agent-workflow-cycle", "assessment"
+            )
+            with self.assertRaises(ui.core.SpecError):
+                ui._validate_phase_state(bundle)
+            with self.assertRaises(ui.core.SpecError):
+                ui.SessionRuntime(bundle).render()
+
+    def test_intro_rejects_hidden_explanation_in_cycle_scope(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            cycle_dir = root / "mastery-sessions" / "agent-workflow-cycle"
+            (cycle_dir / "assessment" / "responses").mkdir(parents=True)
+            raw_spec = assessment_spec()
+            first = raw_spec["questions"][0]
+            correct = next(
+                item
+                for item in first["options"]
+                if item["id"] == first["correct_option_id"]
+            )
+            raw_cycle = cycle_spec()
+            raw_cycle["knowledge_scope"]["includes"][0] = correct["explanation"]
+            (cycle_dir / "cycle.json").write_text(
+                json.dumps(raw_cycle, ensure_ascii=False), encoding="utf-8"
+            )
+            (cycle_dir / "assessment" / "spec.json").write_text(
+                json.dumps(raw_spec, ensure_ascii=False), encoding="utf-8"
+            )
+            bundle = ui.load_phase_bundle(
+                root, "mastery-sessions/agent-workflow-cycle", "assessment"
+            )
+            with self.assertRaises(ui.core.SpecError):
+                ui._validate_phase_state(bundle)
+
+    def test_question_hides_future_and_answer_data(self):
+        with tempfile.TemporaryDirectory() as directory:
+            _, bundle = write_assessment_workspace(Path(directory))
+            runtime = ui.SessionRuntime(bundle)
+            runtime.start({"request_id": "start-1"})
+            page = runtime.render()
+            first = bundle.spec["questions"][0]
+            future = bundle.spec["questions"][1]
+            self.assertIn(first["prompt"], page)
+            self.assertIn(first["options"][0]["description"], page)
+            self.assertNotIn(future["prompt"], page)
+            self.assertNotIn(first["correct_option_id"], page)
+            self.assertNotIn(first["options"][0]["explanation"], page)
+            self.assertNotIn(first["options"][1]["misconception_tag"], page)
+            self.assertNotIn("/record", page)
+            self.assertNotIn("記錄這個錯誤", page)
+            self.assertIn("<progress", page)
+            self.assertIn("第 1 / 12 題", page)
+
+    def test_sealed_legacy_batch_hides_entire_unsafe_description_set(self):
+        unsafe_descriptions = (
+            "符合這一題的遺傳核心命題。",
+            "This is the preferred approach.",
+            "This choice should be selected.",
+            "這是首選做法。",
+            "Status: PASS; all gates are satisfied.",
+            "This response earns full credit.",
+            "評分：滿分。",
+            "Meets every requirement with no unresolved gaps.",
+            "所有條件皆已滿足，沒有缺口。",
+            "這個說法已涵蓋題目所需的所有機制。",
+            "已全面涵蓋題目機制；其他延伸細節另行處理。",
+            "Comprehensively covers the requested mechanisms; downstream details remain separate.",
+            "Satisfies the criteria in the prompt; downstream cases remain separate.",
+            "Meets the condition in the prompt.",
+            "The answer; downstream cases remain separate.",
+            "Describes a plausible workflow action.",
+            "description-other-option-label",
+            "description-own-label-positive",
+            "description-own-label-negative",
+            "description-short-own-label-negative",
+            "description-cjk-own-label-negative",
+            "zero-width-stable-id",
+            "zero-width-future-correct-label",
+            "short-stopword-id-suffix-context",
+            "✅",
+            "future-prompt",
+            "short-future-prompt",
+            "future-correct-label",
+            "stable-option-id",
+            "embedded-stable-option-id",
+            "plain-stable-option-id",
+        )
+        for unsafe_case in unsafe_descriptions:
+            with self.subTest(description=unsafe_case), tempfile.TemporaryDirectory() as directory:
+                root = Path(directory)
+                cycle_dir, _ = write_assessment_workspace(root)
+                raw = assessment_spec()
+                apply_unsafe_choice_case(raw, unsafe_case)
+                spec_path = cycle_dir / "assessment" / "spec.json"
+                spec_path.write_text(
+                    json.dumps(raw, ensure_ascii=False), encoding="utf-8"
+                )
+                normalized = ui.core.validate_assessment_spec(
+                    raw, ui.core.validate_cycle(cycle_spec())
+                )
+                ui.core.write_json_once(
+                    cycle_dir / "assessment" / "batch-manifest.json",
+                    {
+                        "schema_version": 3,
+                        "record_type": "batch_manifest",
+                        "phase": "assessment",
+                        "cycle_id": normalized["cycle_id"],
+                        "cycle_contract_digest": normalized[
+                            "cycle_contract_digest"
+                        ],
+                        "spec_digest": ui.core._batch_spec_digest(normalized),
+                        "question_ids": [
+                            item["question_id"] for item in normalized["questions"]
+                        ],
+                        "sealed_at": ui.core.utc_now(),
+                    },
+                )
+
+                bundle = ui.load_phase_bundle(
+                    root, "mastery-sessions/agent-workflow-cycle", "assessment"
+                )
+                page = ui.SessionRuntime(bundle).render()
+                first = bundle.spec["questions"][0]
+                for option in first["options"]:
+                    self.assertIn(option["label"], page)
+                    self.assertNotIn(option["description"], page)
+                self.assertNotIn('class="choice-desc"', page)
+
+    def test_sealed_legacy_batch_blocks_unsafe_prompt_surface(self):
+        for unsafe_case in (
+            "prompt-hidden-explanation",
+            "prompt-stable-option-id",
+            "prompt-correct-position",
+            "prompt-correct-label",
+            "prompt-future-wrong-explanation",
+            "prompt-future-wrong-label",
+            "prompt-current-wrong-label",
+            "prompt-option-letter",
+            "prompt-option-number",
+            "prompt-option-chinese-letter",
+            "prompt-first-full-credit",
+            "prompt-top-answer",
+            "scenario-option-full-credit",
+            "intro-future-correct-label",
+            "intro-stable-option-id",
+            "short-correct-id-label",
+            "short-wrong-id-label",
+            "prompt-equals-correct-label",
+            "prompt-contains-correct-label",
+            "prompt-short-correct-label",
+            "repeated-prompt-correct-label",
+            "label-future-correct",
+        ):
+            with self.subTest(case=unsafe_case), tempfile.TemporaryDirectory() as directory:
+                root = Path(directory)
+                cycle_dir, _ = write_assessment_workspace(root)
+                raw = assessment_spec()
+                apply_unsafe_choice_case(raw, unsafe_case)
+                (cycle_dir / "assessment" / "spec.json").write_text(
+                    json.dumps(raw, ensure_ascii=False), encoding="utf-8"
+                )
+                normalized = ui.core.validate_assessment_spec(
+                    raw, ui.core.validate_cycle(cycle_spec())
+                )
+                ui.core.write_json_once(
+                    cycle_dir / "assessment" / "batch-manifest.json",
+                    {
+                        "schema_version": 3,
+                        "record_type": "batch_manifest",
+                        "phase": "assessment",
+                        "cycle_id": normalized["cycle_id"],
+                        "cycle_contract_digest": normalized[
+                            "cycle_contract_digest"
+                        ],
+                        "spec_digest": ui.core._batch_spec_digest(normalized),
+                        "question_ids": [
+                            item["question_id"] for item in normalized["questions"]
+                        ],
+                        "sealed_at": ui.core.utc_now(),
+                    },
+                )
+                bundle = ui.load_phase_bundle(
+                    root, "mastery-sessions/agent-workflow-cycle", "assessment"
+                )
+                with self.assertRaises(ui.core.SpecError):
+                    ui._validate_phase_state(bundle)
+                with self.assertRaises(ui.core.SpecError):
+                    ui.SessionRuntime(bundle).render()
+
+    def test_sealed_legacy_batch_allows_repeated_prompt_template(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            cycle_dir, _ = write_assessment_workspace(root)
+            raw = assessment_spec()
+            repeated_prompt = "Choose the action that preserves the stated boundary."
+            for question in raw["questions"]:
+                question["prompt"] = repeated_prompt
+            (cycle_dir / "assessment" / "spec.json").write_text(
+                json.dumps(raw, ensure_ascii=False), encoding="utf-8"
+            )
+            normalized = ui.core.validate_assessment_spec(
+                raw, ui.core.validate_cycle(cycle_spec())
+            )
+            ui.core.write_json_once(
+                cycle_dir / "assessment" / "batch-manifest.json",
+                {
+                    "schema_version": 3,
+                    "record_type": "batch_manifest",
+                    "phase": "assessment",
+                    "cycle_id": normalized["cycle_id"],
+                    "cycle_contract_digest": normalized["cycle_contract_digest"],
+                    "spec_digest": ui.core._batch_spec_digest(normalized),
+                    "question_ids": [
+                        item["question_id"] for item in normalized["questions"]
+                    ],
+                    "sealed_at": ui.core.utc_now(),
+                },
+            )
+            bundle = ui.load_phase_bundle(
+                root, "mastery-sessions/agent-workflow-cycle", "assessment"
+            )
+            state = ui._validate_phase_state(bundle)
+            self.assertFalse(state["complete"])
+            runtime = ui.SessionRuntime(bundle)
+            runtime.start({"request_id": "start-template"})
+            self.assertIn(repeated_prompt, runtime.render())
+
+    def test_wrong_answer_saves_immediately_and_explains_both(self):
+        with tempfile.TemporaryDirectory() as directory:
+            cycle_dir, bundle = write_assessment_workspace(Path(directory))
+            runtime = ui.SessionRuntime(bundle)
+            runtime.start({"request_id": "start-1"})
+            question = bundle.spec["questions"][0]
+            option_tokens = runtime._option_tokens[question["question_id"]]
+            wrong_token, wrong = option_tokens[1]
+            page = runtime.answer(
+                {
+                    "request_id": "answer-1",
+                    "question_token": runtime._question_tokens[question["question_id"]],
+                    "option_token": wrong_token,
+                }
+            )
+            response_path = cycle_dir / "assessment" / "responses" / f"{question['question_id']}.json"
+            self.assertTrue(response_path.is_file())
+            self.assertIn(wrong["explanation"], page)
+            correct = next(
+                option for option in question["options"] if option["id"] == question["correct_option_id"]
+            )
+            self.assertIn(correct["explanation"], page)
+            self.assertIn("下一題", page)
+            self.assertNotIn("記錄這個錯誤", page)
+
+    def test_refresh_and_restart_restore_feedback_until_next(self):
+        with tempfile.TemporaryDirectory() as directory:
+            _, bundle = write_assessment_workspace(Path(directory))
+            runtime = ui.SessionRuntime(bundle)
+            runtime.start({"request_id": "start-1"})
+            question = bundle.spec["questions"][0]
+            token, _ = runtime._option_tokens[question["question_id"]][0]
+            runtime.answer(
+                {
+                    "request_id": "answer-1",
+                    "question_token": runtime._question_tokens[question["question_id"]],
+                    "option_token": token,
+                }
+            )
+            restarted = ui.SessionRuntime(bundle)
+            page = restarted.render()
+            self.assertIn("回答正確", page)
+            self.assertIn("下一題", page)
+            state = restarted._checkpoint()
+            self.assertEqual(state["screen"], "feedback")
+            self.assertEqual(state["index"], 0)
+
+    def test_twelve_answers_emit_server_report(self):
+        with tempfile.TemporaryDirectory() as directory:
+            cycle_dir, bundle = write_assessment_workspace(Path(directory))
+            runtime = ui.SessionRuntime(bundle)
+            runtime.start({"request_id": "start-1"})
+            final_page = ""
+            for index, question in enumerate(bundle.spec["questions"]):
+                option_token, _ = runtime._option_tokens[question["question_id"]][index % 2]
+                runtime.answer(
+                    {
+                        "request_id": f"answer-{index}",
+                        "question_token": runtime._question_tokens[question["question_id"]],
+                        "option_token": option_token,
+                    }
+                )
+                final_page = runtime.next(
+                    {
+                        "request_id": f"next-{index}",
+                        "next_token": runtime._next_tokens[question["question_id"]],
+                    }
+                )
+            report_path = cycle_dir / "assessment" / "report.json"
+            self.assertTrue(report_path.is_file())
+            report = json.loads(report_path.read_text(encoding="utf-8"))
+            self.assertEqual(report["answered"], 12)
+            self.assertEqual(len(report["area_results"]), 3)
+            self.assertIn("你的知識訊號總表", final_page)
+            self.assertIn("題目追溯", final_page)
+            self.assertIn("請關閉此頁並回到 Codex", final_page)
+
+    def test_future_and_stale_navigation_tokens_are_rejected(self):
+        with tempfile.TemporaryDirectory() as directory:
+            _, bundle = write_assessment_workspace(Path(directory))
+            runtime = ui.SessionRuntime(bundle)
+            runtime.start({"request_id": "start-1"})
+            second = bundle.spec["questions"][1]
+            with self.assertRaises(ui.UiError):
+                runtime.answer(
+                    {
+                        "request_id": "answer-future",
+                        "question_token": runtime._question_tokens[second["question_id"]],
+                        "option_token": runtime._option_tokens[second["question_id"]][0][0],
+                    }
+                )
+            with self.assertRaises(ui.UiError):
+                runtime.next({"request_id": "next-stale", "next_token": "stale"})
+
+
+class LearningUiTests(unittest.TestCase):
+    def test_map_previews_titles_but_lazily_reveals_content(self):
+        with tempfile.TemporaryDirectory() as directory:
+            _, bundle = write_learning_workspace(Path(directory))
+            runtime = ui.SessionRuntime(bundle)
+            intro = runtime.render()
+            first, second = list(bundle.slices.values())[:2]
+            self.assertIn(first["title"], intro)
+            self.assertIn(second["title"], intro)
+            self.assertNotIn(first["core_explanation"], intro)
+            self.assertNotIn(second["worked_example"]["walkthrough"], intro)
+            first_page = runtime.start({"request_id": "start-learning"})
+            self.assertIn(first["core_explanation"], first_page)
+            self.assertNotIn(second["core_explanation"], first_page)
+            self.assertIn("完成閱讀只計學習進度", intro)
+            with self.assertRaises(ui.UiError):
+                runtime.view_slice(second["slice_id"])
+
+    def test_map_rejects_checkpoint_explanation_in_locked_slice_title(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            cycle_dir, bundle = write_learning_workspace(root)
+            area = bundle.spec["areas"][0]
+            correct = next(
+                item
+                for item in area["checkpoint"]["options"]
+                if item["id"] == area["checkpoint"]["correct_option_id"]
+            )
+            locked_id = area["slice_ids"][1]
+            slice_path = cycle_dir / "learning" / "slices" / f"{locked_id}.json"
+            raw_slice = json.loads(slice_path.read_text(encoding="utf-8"))
+            raw_slice["title"] = correct["explanation"]
+            slice_path.write_text(
+                json.dumps(raw_slice, ensure_ascii=False), encoding="utf-8"
+            )
+            reloaded = ui.load_phase_bundle(
+                root, "mastery-sessions/agent-workflow-cycle", "learning"
+            )
+            with self.assertRaises(ui.core.SpecError):
+                ui._validate_phase_state(reloaded)
+            with self.assertRaises(ui.core.SpecError):
+                ui.SessionRuntime(reloaded).render()
+
+    def test_slice_events_are_write_once_and_completed_nodes_can_reopen(self):
+        with tempfile.TemporaryDirectory() as directory:
+            cycle_dir, bundle = write_learning_workspace(Path(directory))
+            runtime = ui.SessionRuntime(bundle)
+            runtime.start({"request_id": "start-learning"})
+            first_id = bundle.spec["areas"][0]["slice_ids"][0]
+            next_page = runtime.complete_slice(
+                {
+                    "request_id": "complete-first",
+                    "slice_token": runtime._slice_tokens[first_id],
+                }
+            )
+            event = cycle_dir / "learning" / "events" / f"slice_completed.{first_id}.json"
+            self.assertTrue(event.is_file())
+            self.assertIn(bundle.spec["areas"][0]["slice_ids"][1], runtime._slice_tokens)
+            self.assertIn("知識地圖 · 2 / 15", next_page)
+            retry_page = runtime.complete_slice(
+                {
+                    "request_id": "complete-first-retry",
+                    "slice_token": runtime._slice_tokens[first_id],
+                }
+            )
+            self.assertIn("知識地圖 · 2 / 15", retry_page)
+            review_page = runtime.view_slice(first_id)
+            self.assertIn("回到目前進度", review_page)
+            self.assertIn(bundle.slices[first_id]["core_explanation"], review_page)
+
+    def test_three_areas_slices_checks_and_report(self):
+        with tempfile.TemporaryDirectory() as directory:
+            cycle_dir, bundle = write_learning_workspace(Path(directory))
+            runtime = ui.SessionRuntime(bundle)
+            runtime.start({"request_id": "start-learning"})
+            final_page = ""
+            for area_index, area in enumerate(bundle.spec["areas"]):
+                for slice_id in area["slice_ids"]:
+                    final_page = runtime.complete_slice(
+                        {
+                            "request_id": f"complete-{slice_id}",
+                            "slice_token": runtime._slice_tokens[slice_id],
+                        }
+                    )
+                self.assertIn("形成性檢核", final_page)
+                tokens = runtime._learning_option_tokens[area["area_id"]]
+                if area_index == 0:
+                    option_token, _ = next(
+                        pair
+                        for pair in tokens
+                        if pair[1]["id"] != area["checkpoint"]["correct_option_id"]
+                    )
+                else:
+                    option_token, _ = next(
+                        pair
+                        for pair in tokens
+                        if pair[1]["id"] == area["checkpoint"]["correct_option_id"]
+                    )
+                feedback = runtime.answer_checkpoint(
+                    {
+                        "request_id": f"check-{area['area_id']}",
+                        "question_token": runtime._learning_question_tokens[area["area_id"]],
+                        "option_token": option_token,
+                    }
+                )
+                self.assertIn("檢核結果", feedback)
+                final_page = runtime.next_checkpoint(
+                    {
+                        "request_id": f"check-next-{area['area_id']}",
+                        "next_token": runtime._learning_next_tokens[area["area_id"]],
+                    }
+                )
+            report_path = cycle_dir / "learning" / "report.json"
+            self.assertTrue(report_path.is_file())
+            report = json.loads(report_path.read_text(encoding="utf-8"))
+            self.assertTrue(report["complete"])
+            self.assertEqual(report["completed_slices"], 15)
+            self.assertEqual(len(report["gaps"]), 1)
+            self.assertIn("知識地圖已走完", final_page)
+            self.assertIn("mastery 等級", final_page)
+
+
+class ReviewUiTests(unittest.TestCase):
+    def test_intro_and_question_conceal_future_answer_surfaces(self):
+        with tempfile.TemporaryDirectory() as directory:
+            _, bundle = write_review_workspace(Path(directory))
+            runtime = ui.SessionRuntime(bundle)
+            intro = runtime.render()
+            self.assertIn("整合複習", intro)
+            self.assertIn("全新情境", intro)
+            self.assertIn("8 題", intro)
+            page = runtime.start({"request_id": "start-review"})
+            first, future = bundle.spec["questions"][:2]
+            self.assertIn(first["prompt"], page)
+            self.assertNotIn(future["prompt"], page)
+            self.assertNotIn(first["correct_option_id"], page)
+            self.assertNotIn(first["options"][0]["explanation"], page)
+            self.assertNotIn("/record", page)
+
+    def test_eight_answers_emit_comparison_and_delayed_review(self):
+        with tempfile.TemporaryDirectory() as directory:
+            cycle_dir, bundle = write_review_workspace(Path(directory))
+            runtime = ui.SessionRuntime(bundle)
+            runtime.start({"request_id": "start-review"})
+            final_page = ""
+            for index, question in enumerate(bundle.spec["questions"]):
+                choose_correct = index in {0, 1, 2, 3, 6, 7}
+                target_id = question["correct_option_id"]
+                option_token, option = next(
+                    pair
+                    for pair in runtime._option_tokens[question["question_id"]]
+                    if (pair[1]["id"] == target_id) is choose_correct
+                )
+                feedback = runtime.answer(
+                    {
+                        "request_id": f"review-answer-{index}",
+                        "question_token": runtime._question_tokens[question["question_id"]],
+                        "option_token": option_token,
+                    }
+                )
+                self.assertIn(option["explanation"], feedback)
+                final_page = runtime.next(
+                    {
+                        "request_id": f"review-next-{index}",
+                        "next_token": runtime._next_tokens[question["question_id"]],
+                    }
+                )
+            report_path = cycle_dir / "review" / "report.json"
+            report = json.loads(report_path.read_text(encoding="utf-8"))
+            self.assertTrue(report["complete"])
+            self.assertTrue(report["corrected_gap_ids"])
+            self.assertTrue(report["remaining_gap_ids"])
+            self.assertTrue(report["new_errors"])
+            self.assertTrue(report["reinforced_concepts"])
+            self.assertTrue(report["delayed_review"])
+            self.assertIn("評估錯誤 → 複習修正", final_page)
+            self.assertIn("延遲複習清單", final_page)
+            self.assertIn("完成日後三天", final_page)
+            response = json.loads(
+                (cycle_dir / "review" / "responses" / "review-q00.json").read_text(
+                    encoding="utf-8"
+                )
+            )
+            self.assertTrue(response["feedback_exposed"])
+
+
+class V3HttpContractTests(unittest.TestCase):
+    def setUp(self):
+        self.temporary = tempfile.TemporaryDirectory()
+        _, bundle = write_assessment_workspace(Path(self.temporary.name))
+        self.runtime = ui.SessionRuntime(bundle)
+        self.runtime.start({"request_id": "http-start"})
+        self.server = ui._create_server(self.runtime, 0)
+        self.thread = threading.Thread(target=self.server.serve_forever)
+        self.thread.start()
+        self.url = f"http://127.0.0.1:{self.server.server_address[1]}"
+
+    def tearDown(self):
+        self.server.shutdown()
+        self.thread.join(timeout=3)
+        self.server.server_close()
+        self.temporary.cleanup()
+
+    def get(self, path: str = "/"):
+        with urllib.request.urlopen(self.url + path, timeout=3) as response:
+            return response.read().decode("utf-8"), response.headers
+
+    def post(
+        self,
+        path: str,
+        payload: dict,
+        *,
+        token: str | None = None,
+        origin: str | None = None,
+    ):
+        headers = {
+            "Content-Type": "application/json",
+            "X-Mastery-Token": token if token is not None else self.runtime.csrf,
+        }
+        if origin is not None:
+            headers["Origin"] = origin
+        request = urllib.request.Request(
+            self.url + path,
+            data=json.dumps(payload).encode("utf-8"),
+            headers=headers,
+            method="POST",
+        )
+        with urllib.request.urlopen(request, timeout=3) as response:
+            return response.read().decode("utf-8"), response.headers
+
+    def test_security_headers_and_no_record_route(self):
+        page, headers = self.get()
+        self.assertIn("第 1 / 12 題", page)
+        self.assertIn("frame-ancestors 'none'", headers["Content-Security-Policy"])
+        self.assertEqual(headers["X-Frame-Options"], "DENY")
+        self.assertEqual(headers["X-Content-Type-Options"], "nosniff")
+        self.assertEqual(headers["Cache-Control"], "no-store")
+        with self.assertRaises(urllib.error.HTTPError) as rejected:
+            self.post("/record", {"request_id": "record-does-not-exist"})
+        self.assertEqual(rejected.exception.code, 404)
+        with self.assertRaises(urllib.error.HTTPError) as csrf_rejected:
+            self.post("/next", {"request_id": "csrf-fail"}, token="wrong")
+        self.assertEqual(csrf_rejected.exception.code, 403)
+        with self.assertRaises(urllib.error.HTTPError) as origin_rejected:
+            self.post(
+                "/next",
+                {"request_id": "origin-fail"},
+                origin="https://attacker.example",
+            )
+        self.assertEqual(origin_rejected.exception.code, 403)
+        with self.assertRaises(urllib.error.HTTPError) as body_rejected:
+            self.post("/next", {"request_id": "body-limit", "padding": "x" * 70000})
+        self.assertEqual(body_rejected.exception.code, 413)
+
+    def test_storage_failure_returns_http_500_instead_of_disconnect(self):
+        def fail_storage(_payload):
+            raise OSError("simulated storage failure")
+
+        self.runtime.start = fail_storage
+        with self.assertRaises(urllib.error.HTTPError) as rejected:
+            self.post("/start", {"request_id": "storage-failure"})
+        self.assertEqual(rejected.exception.code, 500)
+        self.assertIn("Storage unavailable", rejected.exception.read().decode("utf-8"))
+
+    def test_retry_is_idempotent_and_conflicting_answer_is_409(self):
+        question = self.runtime.bundle.spec["questions"][0]
+        first_token = self.runtime._option_tokens[question["question_id"]][0][0]
+        second_token = self.runtime._option_tokens[question["question_id"]][1][0]
+        base = {
+            "question_token": self.runtime._question_tokens[question["question_id"]],
+            "option_token": first_token,
+        }
+        first, _ = self.post("/answer", {"request_id": "http-answer-1", **base})
+        retry, _ = self.post("/answer", {"request_id": "http-answer-retry", **base})
+        self.assertIn("下一題", first)
+        self.assertIn("下一題", retry)
+        with self.assertRaises(urllib.error.HTTPError) as conflict:
+            self.post(
+                "/answer",
+                {
+                    "request_id": "http-answer-conflict",
+                    "question_token": base["question_token"],
+                    "option_token": second_token,
+                },
+            )
+        self.assertEqual(conflict.exception.code, 409)
+        next_payload = {
+            "request_id": "http-next-1",
+            "next_token": self.runtime._next_tokens[question["question_id"]],
+        }
+        advanced, _ = self.post("/next", next_payload)
+        retried, _ = self.post(
+            "/next", {**next_payload, "request_id": "http-next-retry"}
+        )
+        second = self.runtime.bundle.spec["questions"][1]
+        self.assertIn(second["prompt"], advanced)
+        self.assertIn(second["prompt"], retried)
+
+
+class CheckpointRecoveryTests(unittest.TestCase):
+    def test_unsealed_first_question_checkpoint_returns_to_intro(self):
+        with tempfile.TemporaryDirectory() as directory:
+            cycle_dir, bundle = write_assessment_workspace(Path(directory))
+            first = bundle.spec["questions"][0]
+            ui.core.atomic_write_json(
+                cycle_dir / "checkpoint.json",
+                {
+                    "schema_version": 3,
+                    "cycle_id": bundle.cycle["cycle_id"],
+                    "phase": "assessment",
+                    "screen": "question",
+                    "index": 0,
+                    "subject_id": first["question_id"],
+                },
+            )
+
+            runtime = ui.SessionRuntime(bundle)
+            page = runtime.render()
+            self.assertIn("確認範圍並開始", page)
+            self.assertNotIn(first["prompt"], page)
+            self.assertFalse(
+                (cycle_dir / "assessment" / "batch-manifest.json").exists()
+            )
+
+            started = runtime.start({"request_id": "seal-after-recovery"})
+            self.assertIn(first["prompt"], started)
+            self.assertTrue(
+                (cycle_dir / "assessment" / "batch-manifest.json").is_file()
+            )
+
+    def test_corrupt_checkpoint_rebuilds_conservative_feedback(self):
+        with tempfile.TemporaryDirectory() as directory:
+            cycle_dir, bundle = write_assessment_workspace(Path(directory))
+            runtime = ui.SessionRuntime(bundle)
+            runtime.start({"request_id": "start-recovery"})
+            question = bundle.spec["questions"][0]
+            runtime.answer(
+                {
+                    "request_id": "answer-recovery",
+                    "question_token": runtime._question_tokens[question["question_id"]],
+                    "option_token": runtime._option_tokens[question["question_id"]][0][0],
+                }
+            )
+            (cycle_dir / "checkpoint.json").write_text("{broken", encoding="utf-8")
+            restarted = ui.SessionRuntime(bundle)
+            page = restarted.render()
+            self.assertIn("回答正確", page)
+            self.assertEqual(restarted._checkpoint()["screen"], "feedback")
+
+    def test_future_checkpoint_cannot_jump_to_last_question(self):
+        with tempfile.TemporaryDirectory() as directory:
+            cycle_dir, bundle = write_assessment_workspace(Path(directory))
+            ui.core.atomic_write_json(
+                cycle_dir / "checkpoint.json",
+                {
+                    "schema_version": 3,
+                    "cycle_id": bundle.cycle["cycle_id"],
+                    "phase": "assessment",
+                    "screen": "question",
+                    "index": 11,
+                    "subject_id": bundle.spec["questions"][11]["question_id"],
+                },
+            )
+            runtime = ui.SessionRuntime(bundle)
+            page = runtime.render()
+            self.assertIn("確認範圍並開始", page)
+            self.assertNotIn(bundle.spec["questions"][11]["prompt"], page)
+
+    def test_learning_load_rebuilds_report_and_review_rejects_empty_event(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            cycle_dir, bundle = write_learning_workspace(root)
+            (cycle_dir / "assessment" / "report.json").write_text(
+                json.dumps({"gaps": [{"gap_id": "forged"}]}), encoding="utf-8"
+            )
+            rebuilt = ui.load_phase_bundle(
+                root, "mastery-sessions/agent-workflow-cycle", "learning"
+            )
+            self.assertEqual(rebuilt.assessment_report["gaps"], [])
+
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            cycle_dir, _ = write_review_workspace(root)
+            first_event = next(
+                (cycle_dir / "learning" / "events").glob("slice_completed.*.json")
+            )
+            first_event.write_text("{}", encoding="utf-8")
+            with self.assertRaises(ui.core.SpecError):
+                ui.load_phase_bundle(
+                    root, "mastery-sessions/agent-workflow-cycle", "review"
+                )
+
+    def test_cycle_reference_cannot_escape_workspace(self):
+        with tempfile.TemporaryDirectory() as directory:
+            with self.assertRaises(ui.core.SpecError):
+                ui.load_phase_bundle(Path(directory), "../outside", "assessment")
+
+
+class PublicCliTests(unittest.TestCase):
+    def command(self, workspace: Path, phase: str, action: str = "validate"):
+        values = [
+            sys.executable,
+            str(ROOT / "scripts" / "mastery_session_ui.py"),
+            action,
+            "--workspace",
+            str(workspace),
+            "--cycle",
+            "mastery-sessions/agent-workflow-cycle",
+            "--phase",
+            phase,
+        ]
+        if action == "serve":
+            values.extend(["--port", "0", "--idle-timeout", "1"])
+        return subprocess.run(values, capture_output=True, text=True, timeout=8)
+
+    def test_validate_supports_all_three_phases(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            assessment_root = root / "assessment-workspace"
+            learning_root = root / "learning-workspace"
+            review_root = root / "review-workspace"
+            write_assessment_workspace(assessment_root)
+            write_learning_workspace(learning_root)
+            write_review_workspace(review_root)
+            for workspace, phase in (
+                (assessment_root, "assessment"),
+                (learning_root, "learning"),
+                (review_root, "review"),
+            ):
+                result = self.command(workspace, phase)
+                self.assertEqual(result.returncode, 0, result.stderr)
+                payload = json.loads(result.stdout)
+                self.assertTrue(payload["ok"])
+                self.assertEqual(payload["phase"], phase)
+
+    def test_validate_and_serve_reject_unsafe_choice_copy_before_seal(self):
+        for unsafe_case in (
+            "符合這一題的遺傳核心命題。",
+            "This is the preferred approach.",
+            "future-prompt",
+            "short-future-prompt",
+            "future-correct-label",
+            "stable-option-id",
+            "embedded-stable-option-id",
+            "plain-stable-option-id",
+            "prompt-hidden-explanation",
+            "prompt-stable-option-id",
+            "prompt-correct-position",
+            "prompt-correct-label",
+            "prompt-future-wrong-explanation",
+            "prompt-future-wrong-label",
+            "prompt-current-wrong-label",
+            "description-other-option-label",
+            "prompt-option-letter",
+            "prompt-option-number",
+            "prompt-option-chinese-letter",
+            "prompt-first-full-credit",
+            "prompt-top-answer",
+            "scenario-option-full-credit",
+            "intro-future-correct-label",
+            "intro-stable-option-id",
+            "short-correct-id-label",
+            "short-wrong-id-label",
+            "short-stopword-id-suffix-context",
+            "description-own-label-positive",
+            "description-own-label-negative",
+            "description-short-own-label-negative",
+            "description-cjk-own-label-negative",
+            "zero-width-stable-id",
+            "zero-width-future-correct-label",
+            "prompt-equals-correct-label",
+            "prompt-contains-correct-label",
+            "prompt-short-correct-label",
+            "repeated-prompt-correct-label",
+            "label-future-correct",
+            "Status: PASS; all gates are satisfied.",
+            "This response earns full credit.",
+            "Meets every requirement with no unresolved gaps.",
+            "所有條件皆已滿足，沒有缺口。",
+            "這個說法已涵蓋題目所需的所有機制。",
+            "已全面涵蓋題目機制；其他延伸細節另行處理。",
+            "Comprehensively covers the requested mechanisms; downstream details remain separate.",
+            "Satisfies the criteria in the prompt; downstream cases remain separate.",
+            "Meets the condition in the prompt.",
+            "The answer; downstream cases remain separate.",
+            "Describes a plausible workflow action.",
+        ):
+            with self.subTest(description=unsafe_case), tempfile.TemporaryDirectory() as directory:
+                workspace = Path(directory)
+                cycle_dir, _ = write_assessment_workspace(workspace)
+                raw = assessment_spec()
+                apply_unsafe_choice_case(raw, unsafe_case)
+                (cycle_dir / "assessment" / "spec.json").write_text(
+                    json.dumps(raw, ensure_ascii=False), encoding="utf-8"
+                )
+
+                for action in ("validate", "serve"):
+                    result = self.command(workspace, "assessment", action)
+                    self.assertEqual(result.returncode, 2, result.stderr)
+                    payload = json.loads(result.stderr)
+                    self.assertFalse(payload["ok"])
+                    self.assertTrue(
+                        any(
+                            marker in payload["error"]
+                            for marker in (
+                                "reveals correctness",
+                                "hidden or future question content",
+                                "stable internal token",
+                                "must add an explicit boundary",
+                                "must supplement rather than repeat",
+                            )
+                        ),
+                        payload["error"],
+                    )
+                self.assertFalse(
+                    (cycle_dir / "assessment" / "batch-manifest.json").exists()
+                )
+
+    def test_validate_and_lock_rejected_serve_do_not_rewrite_reports(self):
+        with tempfile.TemporaryDirectory() as directory:
+            workspace = Path(directory)
+            cycle_dir, _ = write_learning_workspace(workspace)
+            report_path = cycle_dir / "assessment" / "report.json"
+            sentinel = b'{"sentinel":"preserve-me"}\n'
+            report_path.write_bytes(sentinel)
+
+            validated = self.command(workspace, "learning")
+            self.assertEqual(validated.returncode, 0, validated.stderr)
+            self.assertEqual(report_path.read_bytes(), sentinel)
+
+            with ui.core.PhaseLock(cycle_dir, "assessment"):
+                rejected = self.command(workspace, "learning", "serve")
+            self.assertEqual(rejected.returncode, 2, rejected.stderr)
+            self.assertEqual(report_path.read_bytes(), sentinel)
+
+    def test_validate_rejects_corrupt_phase_evidence(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+
+            assessment_root = root / "assessment"
+            assessment_cycle, assessment_bundle = write_assessment_workspace(
+                assessment_root
+            )
+            first_question = assessment_bundle.spec["questions"][0]
+            ui.core.record_response(
+                assessment_cycle / "assessment",
+                assessment_bundle.spec,
+                first_question["question_id"],
+                first_question["correct_option_id"],
+                [option["id"] for option in first_question["options"]],
+                "corrupt-assessment-fixture",
+            )
+            response_path = (
+                assessment_cycle
+                / "assessment"
+                / "responses"
+                / f"{first_question['question_id']}.json"
+            )
+            response_path.write_text("{}", encoding="utf-8")
+            self.assertEqual(
+                self.command(assessment_root, "assessment").returncode, 2
+            )
+            rejected_serve = self.command(
+                assessment_root, "assessment", "serve"
+            )
+            self.assertEqual(rejected_serve.returncode, 2)
+            self.assertNotIn('"ready": true', rejected_serve.stdout.lower())
+
+            learning_root = root / "learning"
+            learning_cycle, learning_bundle = write_learning_workspace(learning_root)
+            first_slice = learning_bundle.spec["areas"][0]["slice_ids"][0]
+            event_path = (
+                learning_cycle
+                / "learning"
+                / "events"
+                / f"slice_completed.{first_slice}.json"
+            )
+            event_path.write_text("{}", encoding="utf-8")
+            self.assertEqual(self.command(learning_root, "learning").returncode, 2)
+
+            review_root = root / "review"
+            review_cycle, review_bundle = write_review_workspace(review_root)
+            review_question = review_bundle.spec["questions"][0]
+            review_response = (
+                review_cycle
+                / "review"
+                / "responses"
+                / f"{review_question['question_id']}.json"
+            )
+            review_response.write_text("{}", encoding="utf-8")
+            self.assertEqual(self.command(review_root, "review").returncode, 2)
+
+    def test_validate_rejects_invalid_utf8_as_structured_error(self):
+        with tempfile.TemporaryDirectory() as directory:
+            workspace = Path(directory)
+            cycle_dir, _ = write_assessment_workspace(workspace)
+            (cycle_dir / "assessment" / "spec.json").write_bytes(b"\xff\xfe\x00")
+
+            result = self.command(workspace, "assessment")
+            self.assertEqual(result.returncode, 2)
+            self.assertNotIn("Traceback", result.stderr)
+            payload = json.loads(result.stderr)
+            self.assertFalse(payload["ok"])
+            self.assertIn("Invalid JSON object", payload["error"])
+
+    def test_validate_and_serve_reject_evidence_path_directories(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            assessment_root = root / "assessment"
+            learning_root = root / "learning"
+            review_root = root / "review"
+            assessment_cycle, assessment_bundle = write_assessment_workspace(
+                assessment_root
+            )
+            learning_cycle, learning_bundle = write_learning_workspace(
+                learning_root
+            )
+            review_cycle, review_bundle = write_review_workspace(review_root)
+            blocked_paths = (
+                (
+                    assessment_root,
+                    "assessment",
+                    assessment_cycle
+                    / "assessment"
+                    / "responses"
+                    / f"{assessment_bundle.spec['questions'][0]['question_id']}.json",
+                ),
+                (
+                    learning_root,
+                    "learning",
+                    learning_cycle
+                    / "learning"
+                    / "events"
+                    / f"slice_completed.{learning_bundle.spec['areas'][0]['slice_ids'][0]}.json",
+                ),
+                (
+                    review_root,
+                    "review",
+                    review_cycle
+                    / "review"
+                    / "responses"
+                    / f"{review_bundle.spec['questions'][0]['question_id']}.json",
+                ),
+            )
+            for workspace, phase, blocked_path in blocked_paths:
+                blocked_path.mkdir()
+                validated = self.command(workspace, phase)
+                served = self.command(workspace, phase, "serve")
+                self.assertEqual(validated.returncode, 2, validated.stderr)
+                self.assertEqual(served.returncode, 2, served.stderr)
+                self.assertNotIn('"ready": true', served.stdout.lower())
+
+    def test_validate_and_serve_reject_invalid_reserved_write_surfaces(self):
+        case_names = (
+            "responses-file",
+            "events-file",
+            "review-responses-file",
+            "manifest-directory",
+            "checkpoint-directory",
+            "report-directory",
+            "lock-directory",
+        )
+        for case_name in case_names:
+            with self.subTest(case=case_name), tempfile.TemporaryDirectory() as directory:
+                workspace = Path(directory)
+                if case_name == "events-file":
+                    cycle_dir, _ = write_learning_workspace(workspace)
+                    phase = "learning"
+                    blocked = cycle_dir / "learning" / "events"
+                    for child in blocked.iterdir():
+                        child.unlink()
+                    blocked.rmdir()
+                    blocked.write_text("blocked", encoding="utf-8")
+                elif case_name == "review-responses-file":
+                    cycle_dir, _ = write_review_workspace(workspace)
+                    phase = "review"
+                    blocked = cycle_dir / "review" / "responses"
+                    blocked.rmdir()
+                    blocked.write_text("blocked", encoding="utf-8")
+                else:
+                    cycle_dir, _ = write_assessment_workspace(workspace)
+                    phase = "assessment"
+                    if case_name == "responses-file":
+                        blocked = cycle_dir / "assessment" / "responses"
+                        blocked.rmdir()
+                        blocked.write_text("blocked", encoding="utf-8")
+                    elif case_name == "manifest-directory":
+                        (cycle_dir / "assessment" / "batch-manifest.json").mkdir()
+                    elif case_name == "checkpoint-directory":
+                        (cycle_dir / "checkpoint.json").mkdir()
+                    elif case_name == "report-directory":
+                        (cycle_dir / "assessment" / "report.json").mkdir()
+                    else:
+                        (cycle_dir / ".cycle.lock").mkdir()
+
+                validated = self.command(workspace, phase)
+                served = self.command(workspace, phase, "serve")
+                self.assertEqual(validated.returncode, 2, validated.stderr)
+                self.assertEqual(served.returncode, 2, served.stderr)
+                self.assertNotIn('"ready": true', served.stdout.lower())
+
+    def test_mutable_evidence_directory_cannot_link_outside_cycle(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            workspace = root / "workspace"
+            outside = root / "outside"
+            outside.mkdir()
+            cycle_dir, _ = write_assessment_workspace(workspace)
+            responses = cycle_dir / "assessment" / "responses"
+            responses.rmdir()
+            try:
+                os.symlink(outside, responses, target_is_directory=True)
+            except OSError as exc:
+                self.skipTest(f"Symbolic links are unavailable: {exc}")
+
+            validated = self.command(workspace, "assessment")
+            served = self.command(workspace, "assessment", "serve")
+            self.assertEqual(validated.returncode, 2, validated.stderr)
+            self.assertEqual(served.returncode, 2, served.stderr)
+            self.assertNotIn('"ready": true', served.stdout.lower())
+            self.assertEqual(list(outside.iterdir()), [])
+
+    def test_server_close_waits_for_active_request_thread(self):
+        with tempfile.TemporaryDirectory() as directory:
+            workspace = Path(directory)
+            _, bundle = write_assessment_workspace(workspace)
+            runtime = ui.SessionRuntime(bundle)
+            entered = threading.Event()
+            release = threading.Event()
+            closed = threading.Event()
+            client_errors: list[Exception] = []
+            original_render = runtime.render
+
+            def slow_render():
+                entered.set()
+                if not release.wait(3):
+                    raise AssertionError("slow render was not released")
+                return original_render()
+
+            runtime.render = slow_render
+            server = ui._create_server(runtime, 0)
+            serve_thread = threading.Thread(target=server.serve_forever)
+            serve_thread.start()
+            url = f"http://127.0.0.1:{server.server_address[1]}/"
+
+            def request_page():
+                try:
+                    with urllib.request.urlopen(url, timeout=5) as response:
+                        response.read()
+                except Exception as exc:  # pragma: no cover - asserted below
+                    client_errors.append(exc)
+
+            client_thread = threading.Thread(target=request_page)
+            client_thread.start()
+            try:
+                self.assertFalse(server.daemon_threads)
+                self.assertTrue(server.block_on_close)
+                self.assertTrue(entered.wait(2))
+                server.shutdown()
+                serve_thread.join(2)
+                self.assertFalse(serve_thread.is_alive())
+
+                def close_server():
+                    server.server_close()
+                    closed.set()
+
+                close_thread = threading.Thread(target=close_server)
+                close_thread.start()
+                self.assertFalse(closed.wait(0.1))
+                release.set()
+                close_thread.join(2)
+                client_thread.join(2)
+                self.assertTrue(closed.is_set())
+                self.assertFalse(client_thread.is_alive())
+                self.assertEqual(client_errors, [])
+            finally:
+                release.set()
+                server.shutdown()
+                server.server_close()
+                serve_thread.join(2)
+                client_thread.join(2)
+
+    def test_serve_prints_loopback_readiness_and_releases_lock(self):
+        with tempfile.TemporaryDirectory() as directory:
+            workspace = Path(directory)
+            cycle_dir, _ = write_assessment_workspace(workspace)
+            result = self.command(workspace, "assessment", "serve")
+            self.assertEqual(result.returncode, 0, result.stderr)
+            readiness = json.loads(result.stdout.strip().splitlines()[0])
+            self.assertTrue(readiness["ready"])
+            self.assertTrue(readiness["url"].startswith("http://127.0.0.1:"))
+            lock_state = json.loads(
+                (cycle_dir / ".cycle.lock").read_text(encoding="utf-8")
+            )
+            self.assertFalse(lock_state["active"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/weeks/2026/2026-w35-mastery-loop/completed/mastery-loop/tests/test_session_core.py
+++ b/weeks/2026/2026-w35-mastery-loop/completed/mastery-loop/tests/test_session_core.py
@@ -1,0 +1,1527 @@
+from __future__ import annotations
+
+import datetime as dt
+import importlib.util
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def load_module(name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+core = load_module("mastery_session_core", ROOT / "scripts" / "session_core.py")
+
+
+AREAS = ("contracts", "recovery", "evidence")
+
+
+def cycle_spec() -> dict:
+    return {
+        "schema_version": 3,
+        "cycle_id": "agent-workflow-cycle",
+        "mission": {
+            "intent_id": "review_teach",
+            "ultimate_outcome": "Review and teach an end-to-end Agent Workflow.",
+            "audience": "workflow designers",
+        },
+        "knowledge_scope": {
+            "title": "Agent Workflow design",
+            "direction": "Contracts, recovery, and final-state evidence.",
+            "includes": ["handoffs", "idempotency", "acceptance evidence"],
+            "excludes": ["vendor-specific deployment"],
+            "benchmark_status": "verified",
+            "sources": ["Internal workflow acceptance standard v1"],
+        },
+        "areas": [
+            {
+                "area_id": area,
+                "title": area.title(),
+                "description": f"Knowledge and decisions for {area}.",
+                "weight": 1,
+                "failure_cost": 2,
+                "uncertainty": 2,
+            }
+            for area in AREAS
+        ],
+        "artifacts": {
+            "assessment_spec": "assessment/spec.json",
+            "assessment_report": "assessment/report.json",
+            "learning_path": "learning/path.json",
+            "learning_report": "learning/report.json",
+            "review_spec": "review/spec.json",
+            "review_report": "review/report.json",
+        },
+    }
+
+
+def options(prefix: str, correct_position: int = 0) -> tuple[list[dict], str]:
+    correct_id = f"{prefix}-correct"
+    values = [
+        {
+            "id": correct_id,
+            "label": f"{prefix} validate the contract",
+            "description": f"Covers the {prefix} evidence gate; downstream acceptance remains separate.",
+            "explanation": f"In {prefix}, this preserves the invariant before side effects.",
+            "misconception_tag": "",
+        },
+        {
+            "id": f"{prefix}-wrong-a",
+            "label": f"{prefix} continue with partial state",
+            "description": f"Prioritizes {prefix} delivery speed; artifact completeness remains unresolved.",
+            "explanation": f"The partial {prefix} state cannot satisfy the handoff contract.",
+            "misconception_tag": "partial-is-complete",
+        },
+        {
+            "id": f"{prefix}-wrong-b",
+            "label": f"{prefix} infer the missing evidence",
+            "description": f"Fills the {prefix} gap by inference; observable evidence remains unresolved.",
+            "explanation": f"The {prefix} inference cannot replace observable evidence.",
+            "misconception_tag": "inference-as-evidence",
+        },
+    ]
+    correct = values.pop(0)
+    values.insert(correct_position, correct)
+    return values, correct_id
+
+
+def question(index: int, *, area: str | None = None) -> dict:
+    area_id = area or AREAS[index % len(AREAS)]
+    answer_options, correct = options(f"a{index}")
+    return {
+        "question_id": f"assessment-q{index:02d}",
+        "area_id": area_id,
+        "concept_id": f"concept-{index:02d}",
+        "knowledge_kernel_id": f"kernel-{index:02d}",
+        "core_proposition": f"Core decision proposition {index}.",
+        "scenario_id": f"assessment-scenario-{index:02d}",
+        "scenario_context": f"Assessment scenario context number {index}.",
+        "question_family": "application",
+        "title": f"Assessment question {index}",
+        "prompt": f"What is the defensible next action in case {index}?",
+        "sources": ["Internal workflow acceptance standard v1"],
+        "options": answer_options,
+        "correct_option_id": correct,
+        "importance": 9 if index == 0 else 5,
+    }
+
+
+def assessment_spec(count: int = 12) -> dict:
+    return {
+        "schema_version": 3,
+        "phase": "assessment",
+        "cycle_id": "agent-workflow-cycle",
+        "title": "Agent Workflow baseline",
+        "instructions": "Answer every question before reading the final report.",
+        "estimated_minutes": 18,
+        "area_ids": list(AREAS),
+        "questions": [question(index) for index in range(count)],
+    }
+
+
+def checkpoint(area: str, index: int) -> dict:
+    answer_options, correct = options(f"cp-{area}")
+    return {
+        "question_id": f"checkpoint-{area}",
+        "area_id": area,
+        "concept_id": f"checkpoint-concept-{area}",
+        "knowledge_kernel_id": f"checkpoint-kernel-{area}",
+        "core_proposition": f"Integrate the decision rules for {area}.",
+        "scenario_id": f"checkpoint-scenario-{area}",
+        "scenario_context": f"A formative checkpoint for {area}.",
+        "question_family": "sequence",
+        "title": f"{area.title()} checkpoint",
+        "prompt": f"Which sequence integrates {area} safely?",
+        "sources": ["Internal workflow acceptance standard v1"],
+        "options": answer_options,
+        "correct_option_id": correct,
+    }
+
+
+def learning_fixture(counts: dict[str, int] | None = None):
+    counts = counts or {area: 5 for area in AREAS}
+    path = {
+        "schema_version": 3,
+        "phase": "learning",
+        "cycle_id": "agent-workflow-cycle",
+        "title": "Agent Workflow knowledge map",
+        "areas": [],
+    }
+    slices: dict[str, dict] = {}
+    for area_index, area in enumerate(AREAS):
+        slice_ids = [f"{area}-slice-{index}" for index in range(1, counts[area] + 1)]
+        path["areas"].append(
+            {
+                "area_id": area,
+                "title": area.title(),
+                "slice_ids": slice_ids,
+                "checkpoint": checkpoint(area, area_index),
+            }
+        )
+        for index, slice_id in enumerate(slice_ids, start=1):
+            slices[slice_id] = {
+                "schema_version": 3,
+                "slice_id": slice_id,
+                "area_id": area,
+                "title": f"{area.title()} slice {index}",
+                "order": index,
+                "difficulty": "foundation" if index <= 2 else "core",
+                "prerequisites": [slice_ids[index - 2]] if index > 1 else [],
+                "learning_objective": f"Apply {area} decision {index}.",
+                "assessment_question_ids": [
+                    f"assessment-q{area_index + 3 * ((index - 1) % 4):02d}"
+                ],
+                "addresses_gap_ids": [],
+                "core_explanation": f"Core explanation for {area} {index}.",
+                "mechanism": f"Mechanism for {area} {index}.",
+                "boundaries": ["Stop when required evidence is unavailable."],
+                "worked_example": {
+                    "scenario_id": f"lesson-{area}-{index}",
+                    "scenario_context": f"Worked example for {area} slice {index}.",
+                    "walkthrough": "Inspect, decide, validate, and record.",
+                },
+                "common_mistakes": ["Treating a partial result as complete."],
+                "key_takeaways": ["Validate the boundary before continuing."],
+                "sources": ["Internal workflow acceptance standard v1"],
+            }
+    return path, slices
+
+
+def review_spec(count: int = 8) -> dict:
+    questions = []
+    for index in range(count):
+        source = question(index)
+        review_options, correct = options(f"r{index}", correct_position=1)
+        questions.append(
+            {
+                "question_id": f"review-q{index:02d}",
+                "area_id": source["area_id"],
+                "concept_id": source["concept_id"],
+                "primary_kernel_id": source["knowledge_kernel_id"],
+                "integrated_kernel_ids": [f"kernel-{(index + 1) % 12:02d}"],
+                "core_proposition": source["core_proposition"],
+                "source_question_id": source["question_id"],
+                "scenario_id": f"review-scenario-{index:02d}",
+                "scenario_context": f"Novel review scenario context number {index}.",
+                "question_family": "critique",
+                "title": f"Review question {index}",
+                "prompt": f"Which defect matters most in novel case {index}?",
+                "sources": ["Internal workflow acceptance standard v1"],
+                "options": review_options,
+                "correct_option_id": correct,
+                "lineage": {
+                    "assessment_question_ids": [
+                        source["question_id"],
+                        f"assessment-q{(index + 1) % 12:02d}",
+                    ],
+                    "learning_slice_ids": [],
+                    "learning_checkpoint_ids": [],
+                },
+            }
+        )
+    return {
+        "schema_version": 3,
+        "phase": "review",
+        "cycle_id": "agent-workflow-cycle",
+        "title": "Integrated review",
+        "instructions": "Apply the learned kernels in new situations.",
+        "questions": questions,
+    }
+
+
+class CycleAndAssessmentValidationTests(unittest.TestCase):
+    def test_cycle_rejects_custom_artifact_routing(self):
+        value = cycle_spec()
+        value["artifacts"]["assessment_report"] = "custom/report.json"
+        with self.assertRaises(core.SpecError):
+            core.validate_cycle(value)
+
+    def setUp(self):
+        self.cycle = core.validate_cycle(cycle_spec())
+
+    def test_load_cycle_returns_directory_and_normalized_cycle(self):
+        with tempfile.TemporaryDirectory() as directory:
+            workspace = Path(directory)
+            cycle_dir = workspace / "mastery-sessions" / "agent-workflow-cycle"
+            cycle_dir.mkdir(parents=True)
+            (cycle_dir / "cycle.json").write_text(
+                json.dumps(cycle_spec(), ensure_ascii=False), encoding="utf-8"
+            )
+            loaded_dir, loaded = core.load_cycle(
+                workspace, "mastery-sessions/agent-workflow-cycle"
+            )
+            self.assertEqual(loaded_dir, cycle_dir.resolve())
+            self.assertEqual(loaded["cycle_id"], "agent-workflow-cycle")
+
+    def test_assessment_accepts_12_questions_and_three_areas(self):
+        normalized = core.validate_assessment_spec(assessment_spec(), self.cycle)
+        self.assertEqual(len(normalized["questions"]), 12)
+        self.assertEqual(
+            {question["area_id"] for question in normalized["questions"]}, set(AREAS)
+        )
+
+    def test_assessment_rejects_question_count_outside_bounds(self):
+        with self.assertRaises(core.SpecError):
+            core.validate_assessment_spec(assessment_spec(9), self.cycle)
+        with self.assertRaises(core.SpecError):
+            core.validate_assessment_spec(assessment_spec(21), self.cycle)
+
+    def test_assessment_rejects_area_with_fewer_than_two_questions(self):
+        spec = assessment_spec()
+        for item in spec["questions"]:
+            if item["area_id"] == "evidence":
+                item["area_id"] = "contracts"
+        with self.assertRaises(core.SpecError):
+            core.validate_assessment_spec(spec, self.cycle)
+
+    def test_assessment_rejects_duplicate_kernel_and_missing_explanation(self):
+        duplicated = assessment_spec()
+        duplicated["questions"][1]["knowledge_kernel_id"] = duplicated["questions"][0][
+            "knowledge_kernel_id"
+        ]
+        with self.assertRaises(core.SpecError):
+            core.validate_assessment_spec(duplicated, self.cycle)
+        incomplete = assessment_spec()
+        del incomplete["questions"][0]["options"][1]["explanation"]
+        with self.assertRaises(core.SpecError):
+            core.validate_assessment_spec(incomplete, self.cycle)
+        missing_tag = assessment_spec()
+        missing_tag["questions"][0]["options"][1]["misconception_tag"] = ""
+        with self.assertRaises(core.SpecError):
+            core.validate_assessment_spec(missing_tag, self.cycle)
+
+    def test_new_batch_rejects_unhelpful_or_leaking_choice_surfaces(self):
+        cases = {
+            "answer-leak": "符合這一題的遺傳核心命題。",
+            "preferred-approach": "This is the preferred approach.",
+            "select-this-choice": "This choice should be selected.",
+            "chinese-preferred": "這是首選做法。",
+            "direct-selection": "請選這個；它就是答案。",
+            "answer-location": "答案就在這個選項。",
+            "pick-me": "Pick me; all stated prerequisites are satisfied.",
+            "select-me": "選我；所有前置條件都已滿足。",
+            "status-pass": "Status: PASS; all gates are satisfied.",
+            "full-credit": "This response earns full credit.",
+            "maximum-score-with-boundary": "This earns the maximum score, but downstream cases remain outside scope.",
+            "guaranteed-pass-with-boundary": "This choice is guaranteed to pass, but later checks remain separate.",
+            "chinese-guaranteed-pass": "這個選項保證會通過，但後續檢查仍需另行進行。",
+            "chinese-perfect-score": "評分：滿分。",
+            "all-requirements-met": "Meets every requirement with no unresolved gaps.",
+            "all-conditions-met": "所有條件皆已滿足，沒有缺口。",
+            "complete-mechanisms": "這個說法已涵蓋題目所需的所有機制。",
+            "comprehensive-with-boundary": "已全面涵蓋題目機制；其他延伸細節另行處理。",
+            "fully-covers-with-boundary": "Comprehensively covers the requested mechanisms; downstream details remain separate.",
+            "criteria-with-boundary": "Satisfies the criteria in the prompt; downstream cases remain separate.",
+            "condition-in-prompt": "Meets the condition in the prompt.",
+            "standalone-answer": "The answer; downstream cases remain separate.",
+            "this-one-is-right": "This one is right; downstream cases remain separate.",
+            "correct-one": "Correct one; downstream cases remain separate.",
+            "chinese-this-one-is-correct": "這個才正確，但其他條件仍需另行確認。",
+            "generic-without-boundary": "Describes a plausible workflow action.",
+            "symbol-only": "✅",
+            "too-short": "x",
+            "future-prompt": "future-prompt",
+            "stable-option-id": "stable-option-id",
+            "embedded-stable-option-id": "embedded-stable-option-id",
+            "plain-stable-option-id": "plain-stable-option-id",
+            "short-future-prompt": "short-future-prompt",
+            "future-correct-label": "future-correct-label",
+            "short-wrong-stable-id-context": "short-wrong-stable-id-context",
+            "prompt-hidden-explanation": "prompt-hidden-explanation",
+            "prompt-stable-option-id": "prompt-stable-option-id",
+            "prompt-correct-position": "prompt-correct-position",
+            "prompt-correct-label": "prompt-correct-label",
+            "prompt-future-wrong-explanation": "prompt-future-wrong-explanation",
+            "prompt-future-wrong-label": "prompt-future-wrong-label",
+            "prompt-current-wrong-label": "prompt-current-wrong-label",
+            "description-other-option-label": "description-other-option-label",
+            "prompt-option-letter": "prompt-option-letter",
+            "prompt-option-number": "prompt-option-number",
+            "prompt-option-chinese-letter": "prompt-option-chinese-letter",
+            "prompt-first-full-credit": "prompt-first-full-credit",
+            "prompt-top-answer": "prompt-top-answer",
+            "scenario-option-full-credit": "scenario-option-full-credit",
+            "intro-future-correct-label": "intro-future-correct-label",
+            "intro-stable-option-id": "intro-stable-option-id",
+            "short-correct-id-label": "short-correct-id-label",
+            "short-wrong-id-label": "short-wrong-id-label",
+            "short-stopword-id-suffix-context": "short-stopword-id-suffix-context",
+            "prompt-equals-correct-label": "prompt-equals-correct-label",
+            "prompt-contains-correct-label": "prompt-contains-correct-label",
+            "prompt-short-correct-label": "prompt-short-correct-label",
+            "repeated-prompt-correct-label": "repeated-prompt-correct-label",
+            "description-own-label-positive": "description-own-label-positive",
+            "description-own-label-negative": "description-own-label-negative",
+            "description-short-own-label-negative": "description-short-own-label-negative",
+            "description-cjk-own-label-negative": "description-cjk-own-label-negative",
+            "zero-width-stable-id": "zero-width-stable-id",
+            "zero-width-future-correct-label": "zero-width-future-correct-label",
+            "empty": "",
+            "label-repeat": None,
+            "label-repeat-punctuation": "punctuation",
+        }
+        for case_name, description in cases.items():
+            with self.subTest(case=case_name), tempfile.TemporaryDirectory() as directory:
+                raw = assessment_spec()
+                option = raw["questions"][0]["options"][0]
+                if description is None:
+                    option["description"] = option["label"]
+                elif description == "punctuation":
+                    option["description"] = f'{option["label"]}。'
+                elif description == "future-prompt":
+                    option["description"] = raw["questions"][1]["prompt"]
+                elif description == "stable-option-id":
+                    option["description"] = (
+                        "Internal option key: "
+                        f'{raw["questions"][0]["correct_option_id"]}; tracking only.'
+                    )
+                elif description == "embedded-stable-option-id":
+                    option["description"] = (
+                        "Internal marker trace-"
+                        f'{raw["questions"][0]["correct_option_id"]}-copy only.'
+                    )
+                elif description == "plain-stable-option-id":
+                    option["id"] = "correctanswer"
+                    raw["questions"][0]["correct_option_id"] = "correctanswer"
+                    option["description"] = (
+                        "Internal option key correctanswer for workflow tracking."
+                    )
+                elif description == "short-future-prompt":
+                    raw["questions"][1]["prompt"] = "Pick now?"
+                    option["description"] = (
+                        "Boundary note: Pick now? Later context remains separate."
+                    )
+                elif description == "future-correct-label":
+                    future = raw["questions"][1]
+                    future_correct = next(
+                        item
+                        for item in future["options"]
+                        if item["id"] == future["correct_option_id"]
+                    )
+                    option["description"] = future_correct["label"]
+                elif description == "short-wrong-stable-id-context":
+                    question = raw["questions"][0]
+                    for item, option_id in zip(
+                        question["options"], ("a", "b", "c")
+                    ):
+                        item["id"] = option_id
+                    question["correct_option_id"] = "a"
+                    question["options"][1]["description"] = (
+                        "Internal option key b for workflow tracking."
+                    )
+                elif description == "prompt-hidden-explanation":
+                    question = raw["questions"][0]
+                    correct = next(
+                        item
+                        for item in question["options"]
+                        if item["id"] == question["correct_option_id"]
+                    )
+                    question["prompt"] = correct["explanation"]
+                elif description == "prompt-stable-option-id":
+                    question = raw["questions"][0]
+                    question["prompt"] = (
+                        "Use internal option key "
+                        f'{question["correct_option_id"]} before continuing.'
+                    )
+                elif description == "prompt-correct-position":
+                    raw["questions"][0]["prompt"] = (
+                        "The first option is the correct answer."
+                    )
+                elif description == "prompt-correct-label":
+                    question = raw["questions"][0]
+                    correct = next(
+                        item
+                        for item in question["options"]
+                        if item["id"] == question["correct_option_id"]
+                    )
+                    question["prompt"] = f'Choose "{correct["label"]}".'
+                elif description == "prompt-future-wrong-explanation":
+                    future = raw["questions"][1]
+                    wrong = next(
+                        item
+                        for item in future["options"]
+                        if item["id"] != future["correct_option_id"]
+                    )
+                    raw["questions"][0]["prompt"] = wrong["explanation"]
+                elif description == "prompt-future-wrong-label":
+                    future = raw["questions"][1]
+                    wrong = next(
+                        item
+                        for item in future["options"]
+                        if item["id"] != future["correct_option_id"]
+                    )
+                    raw["questions"][0]["prompt"] = (
+                        f'Avoid "{wrong["label"]}"; it fails the contract.'
+                    )
+                elif description == "prompt-current-wrong-label":
+                    question = raw["questions"][0]
+                    wrong = next(
+                        item
+                        for item in question["options"]
+                        if item["id"] != question["correct_option_id"]
+                    )
+                    question["prompt"] = (
+                        f'Avoid "{wrong["label"]}"; it fails the contract.'
+                    )
+                elif description == "description-other-option-label":
+                    question = raw["questions"][0]
+                    correct = next(
+                        item
+                        for item in question["options"]
+                        if item["id"] == question["correct_option_id"]
+                    )
+                    question["options"][1]["description"] = (
+                        f'Unlike "{correct["label"]}", this leaves evidence unresolved.'
+                    )
+                elif description == "prompt-option-letter":
+                    raw["questions"][0]["prompt"] = "Option A is correct."
+                elif description == "prompt-option-number":
+                    raw["questions"][0]["prompt"] = (
+                        "Option 1 is the correct answer."
+                    )
+                elif description == "prompt-option-chinese-letter":
+                    raw["questions"][0]["prompt"] = "選項 A 是正確答案。"
+                elif description == "prompt-first-full-credit":
+                    raw["questions"][0]["prompt"] = (
+                        "The response shown first earns full credit; explain why."
+                    )
+                elif description == "prompt-top-answer":
+                    raw["questions"][0]["prompt"] = (
+                        "The top response is the answer; explain why."
+                    )
+                elif description == "scenario-option-full-credit":
+                    raw["questions"][0]["scenario_context"] = (
+                        "The evaluator marks option A as full credit."
+                    )
+                elif description == "intro-future-correct-label":
+                    future = raw["questions"][1]
+                    correct = next(
+                        item
+                        for item in future["options"]
+                        if item["id"] == future["correct_option_id"]
+                    )
+                    raw["instructions"] = (
+                        f'Answer key for the next item: {correct["label"]}'
+                    )
+                elif description == "intro-stable-option-id":
+                    raw["instructions"] = (
+                        "Internal answer key: "
+                        f'{raw["questions"][1]["correct_option_id"]}'
+                    )
+                elif description == "short-correct-id-label":
+                    question = raw["questions"][0]
+                    for item, option_id in zip(
+                        question["options"], ("win", "lose", "bad")
+                    ):
+                        item["id"] = option_id
+                    question["correct_option_id"] = "win"
+                    question["options"][0]["label"] = (
+                        "win - validate the contract"
+                    )
+                elif description == "short-wrong-id-label":
+                    question = raw["questions"][0]
+                    question["options"][1]["id"] = "bad"
+                    question["options"][1]["label"] = (
+                        "bad - continue with partial state"
+                    )
+                elif description == "short-stopword-id-suffix-context":
+                    question = raw["questions"][0]
+                    for item, option_id in zip(
+                        question["options"], ("a", "b", "c")
+                    ):
+                        item["id"] = option_id
+                    question["correct_option_id"] = "a"
+                    question["options"][0]["description"] = (
+                        "a is the internal option key for workflow tracking."
+                    )
+                elif description == "prompt-equals-correct-label":
+                    question = raw["questions"][0]
+                    correct = next(
+                        item
+                        for item in question["options"]
+                        if item["id"] == question["correct_option_id"]
+                    )
+                    question["prompt"] = correct["label"]
+                elif description == "prompt-contains-correct-label":
+                    question = raw["questions"][0]
+                    correct = next(
+                        item
+                        for item in question["options"]
+                        if item["id"] == question["correct_option_id"]
+                    )
+                    question["prompt"] = (
+                        f'Proceed with "{correct["label"]}" before any side effect.'
+                    )
+                elif description == "prompt-short-correct-label":
+                    question = raw["questions"][0]
+                    correct = next(
+                        item
+                        for item in question["options"]
+                        if item["id"] == question["correct_option_id"]
+                    )
+                    correct["label"] = "Approve"
+                    question["prompt"] = "Required next action: Approve."
+                elif description == "repeated-prompt-correct-label":
+                    future = raw["questions"][3]
+                    correct = next(
+                        item
+                        for item in future["options"]
+                        if item["id"] == future["correct_option_id"]
+                    )
+                    for question in raw["questions"][:4]:
+                        question["prompt"] = correct["label"]
+                elif description == "description-own-label-positive":
+                    option["description"] = (
+                        f'Required next action: {option["label"]}; '
+                        "downstream reporting remains separate."
+                    )
+                elif description == "description-own-label-negative":
+                    option["description"] = (
+                        f'Avoid {option["label"]}; '
+                        "the contract boundary remains unresolved."
+                    )
+                elif description == "description-short-own-label-negative":
+                    option["label"] = "Run"
+                    option["description"] = (
+                        "Avoid Run; the contract boundary remains unresolved."
+                    )
+                elif description == "description-cjk-own-label-negative":
+                    option["label"] = "停"
+                    option["description"] = "不要選停；仍缺少必要條件。"
+                elif description == "zero-width-stable-id":
+                    option["description"] = (
+                        "Internal key a0-\u200bcorrect remains outside the learner surface."
+                    )
+                elif description == "zero-width-future-correct-label":
+                    future = raw["questions"][1]
+                    correct = next(
+                        item
+                        for item in future["options"]
+                        if item["id"] == future["correct_option_id"]
+                    )
+                    disguised = correct["label"][:3] + "\u200b" + correct["label"][3:]
+                    option["description"] = (
+                        f'Avoid {disguised} before approval; the boundary remains open.'
+                    )
+                else:
+                    option["description"] = description
+                normalized = core.validate_assessment_spec(raw, self.cycle)
+                phase_dir = Path(directory) / "assessment"
+                phase_dir.mkdir()
+                with self.assertRaises(core.SpecError):
+                    core.ensure_batch_manifest(phase_dir, normalized)
+                self.assertFalse((phase_dir / "batch-manifest.json").exists())
+
+    def test_short_correct_option_id_does_not_confuse_an_english_article(self):
+        raw = assessment_spec()
+        first = raw["questions"][0]
+        for option, option_id in zip(first["options"], ("a", "b", "c")):
+            option["id"] = option_id
+        first["correct_option_id"] = "a"
+        first["options"][0]["description"] = (
+            "Use a question boundary before execution."
+        )
+        normalized = core.validate_assessment_spec(raw, self.cycle)
+        with tempfile.TemporaryDirectory() as directory:
+            manifest, created = core.ensure_batch_manifest(
+                Path(directory), normalized
+            )
+            self.assertTrue(created)
+            self.assertEqual(manifest["phase"], "assessment")
+
+    def test_stable_id_requires_an_identifier_boundary(self):
+        raw = assessment_spec()
+        first = raw["questions"][0]
+        first["options"][0]["id"] = "safe"
+        first["correct_option_id"] = "safe"
+        first["options"][0]["label"] = "Safety boundary before execution"
+        first["options"][0]["description"] = (
+            "Applies only before execution; downstream acceptance remains separate."
+        )
+        normalized = core.validate_assessment_spec(raw, self.cycle)
+        with tempfile.TemporaryDirectory() as directory:
+            manifest, created = core.ensure_batch_manifest(
+                Path(directory), normalized
+            )
+            self.assertTrue(created)
+            self.assertEqual(manifest["phase"], "assessment")
+
+    def test_new_batch_rejects_answer_revealing_option_label(self):
+        for label in ("這就是正確答案", "The answer", "答案"):
+            with self.subTest(label=label), tempfile.TemporaryDirectory() as directory:
+                raw = assessment_spec()
+                raw["questions"][0]["options"][0]["label"] = label
+                normalized = core.validate_assessment_spec(raw, self.cycle)
+                with self.assertRaises(core.SpecError):
+                    core.ensure_batch_manifest(Path(directory), normalized)
+
+    def test_question_rejects_conflicting_or_multiple_correct_answers(self):
+        conflicting = assessment_spec()
+        conflicting["questions"][0]["correct_option_ids"] = [
+            conflicting["questions"][0]["options"][1]["id"]
+        ]
+        with self.assertRaises(core.SpecError):
+            core.validate_assessment_spec(conflicting, self.cycle)
+        multiple = assessment_spec()
+        multiple["questions"][0]["correct_option_ids"] = [
+            multiple["questions"][0]["options"][0]["id"],
+            multiple["questions"][0]["options"][1]["id"],
+        ]
+        with self.assertRaises(core.SpecError):
+            core.validate_assessment_spec(multiple, self.cycle)
+
+        duplicate_surface = assessment_spec()
+        duplicate_surface["questions"][0]["options"][1]["label"] = (
+            duplicate_surface["questions"][0]["options"][0]["label"]
+        )
+        duplicate_surface["questions"][0]["options"][1]["description"] = (
+            duplicate_surface["questions"][0]["options"][0]["description"]
+        )
+        with self.assertRaises(core.SpecError):
+            core.validate_assessment_spec(duplicate_surface, self.cycle)
+
+
+class ResponseAndAssessmentReportTests(unittest.TestCase):
+    def setUp(self):
+        self.cycle = core.validate_cycle(cycle_spec())
+        self.spec = core.validate_assessment_spec(assessment_spec(), self.cycle)
+
+    def answer(self, phase_dir: Path, question: dict, correct: bool, request_id: str):
+        selected = (
+            question["correct_option_id"]
+            if correct
+            else next(
+                option["id"]
+                for option in question["options"]
+                if option["id"] != question["correct_option_id"]
+            )
+        )
+        return core.record_response(
+            phase_dir,
+            self.spec,
+            question["question_id"],
+            selected,
+            [option["id"] for option in question["options"]],
+            request_id,
+        )
+
+    def test_response_is_write_once_and_request_id_idempotent(self):
+        with tempfile.TemporaryDirectory() as directory:
+            phase_dir = Path(directory)
+            question_item = self.spec["questions"][0]
+            first, created = self.answer(phase_dir, question_item, True, "request-one")
+            second, created_again = self.answer(
+                phase_dir, question_item, True, "request-one"
+            )
+            self.assertTrue(created)
+            self.assertFalse(created_again)
+            self.assertEqual(first, second)
+            self.assertEqual(first["correct_option_id"], question_item["correct_option_id"])
+            self.assertFalse(first["feedback_exposed"])
+            with self.assertRaises(core.ConflictError):
+                self.answer(phase_dir, question_item, False, "request-one")
+            timeout_retry, retry_created = self.answer(
+                phase_dir, question_item, True, "request-two"
+            )
+            self.assertFalse(retry_created)
+            self.assertEqual(timeout_retry, first)
+
+    def test_report_rejects_response_after_server_spec_is_changed(self):
+        with tempfile.TemporaryDirectory() as directory:
+            phase_dir = Path(directory)
+            question_item = self.spec["questions"][0]
+            self.answer(phase_dir, question_item, True, "request-one")
+            changed = json.loads(json.dumps(self.spec))
+            changed["questions"][0]["options"].reverse()
+            with self.assertRaises(core.SpecError):
+                core.build_assessment_report(
+                    phase_dir, changed, require_complete=False
+                )
+
+    def test_response_rejects_invalid_evidence_timestamp(self):
+        with tempfile.TemporaryDirectory() as directory:
+            phase_dir = Path(directory)
+            question_item = self.spec["questions"][0]
+            self.answer(phase_dir, question_item, True, "timestamp-fixture")
+            path = (
+                phase_dir
+                / "responses"
+                / f"{question_item['question_id']}.json"
+            )
+            record = core.read_json_object(path)
+            record["answered_at"] = "garbage"
+            path.write_text(
+                json.dumps(record, ensure_ascii=False), encoding="utf-8"
+            )
+            with self.assertRaises(core.SpecError):
+                core.build_assessment_report(
+                    phase_dir, self.spec, require_complete=False
+                )
+
+    def test_report_recomputes_threshold_signals_and_critical_gaps(self):
+        with tempfile.TemporaryDirectory() as directory:
+            phase_dir = Path(directory)
+            results = {
+                "contracts": [True, True, True, True],
+                "recovery": [True, True, True, False],
+                "evidence": [True, False, False, False],
+            }
+            seen = {area: 0 for area in AREAS}
+            for index, item in enumerate(self.spec["questions"]):
+                offset = seen[item["area_id"]]
+                seen[item["area_id"]] += 1
+                self.answer(
+                    phase_dir,
+                    item,
+                    results[item["area_id"]][offset],
+                    f"request-{index}",
+                )
+            report = core.build_assessment_report(phase_dir, self.spec, persist=True)
+            signals = {item["area_id"]: item["signal"] for item in report["area_results"]}
+            self.assertEqual(signals["contracts"], "stable_signal")
+            self.assertEqual(signals["recovery"], "mixed_signal")
+            self.assertEqual(signals["evidence"], "needs_support")
+            self.assertEqual(len(report["gaps"]), 4)
+            self.assertEqual(len(report["strengths"]), 8)
+            self.assertEqual(
+                len(next(item for item in report["area_results"] if item["area_id"] == "contracts")["strength_question_ids"]),
+                4,
+            )
+            self.assertTrue((phase_dir / "report.json").is_file())
+
+    def test_incomplete_assessment_cannot_emit_final_report(self):
+        with tempfile.TemporaryDirectory() as directory:
+            with self.assertRaises(core.IncompletePhaseError):
+                core.build_assessment_report(Path(directory), self.spec)
+
+
+class LearningValidationAndGateTests(unittest.TestCase):
+    def setUp(self):
+        self.cycle = core.validate_cycle(cycle_spec())
+        raw_path, raw_slices = learning_fixture()
+        self.raw_slices = raw_slices
+        self.path = core.validate_learning_path(
+            raw_path, self.cycle, slices=raw_slices
+        )
+
+    def test_three_areas_five_slices_and_checkpoint_are_valid(self):
+        self.assertEqual(len(self.path["areas"]), 3)
+        self.assertTrue(all(len(area["slice_ids"]) == 5 for area in self.path["areas"]))
+        self.assertTrue(all(area["checkpoint"] for area in self.path["areas"]))
+
+    def test_every_slice_requires_assessment_evidence_link(self):
+        raw_path, raw_slices = learning_fixture()
+        raw_slices["contracts-slice-1"]["assessment_question_ids"] = []
+        with self.assertRaises(core.SpecError):
+            core.validate_learning_path(
+                raw_path,
+                self.cycle,
+                slices=raw_slices,
+                assessment_spec=assessment_spec(),
+            )
+
+    def test_learning_rejects_forward_prerequisite(self):
+        raw_path, raw_slices = learning_fixture()
+        raw_slices["contracts-slice-1"]["prerequisites"] = ["contracts-slice-2"]
+        with self.assertRaises(core.SpecError):
+            core.validate_learning_path(raw_path, self.cycle, slices=raw_slices)
+
+        difficulty_path, difficulty_slices = learning_fixture()
+        difficulty_slices["contracts-slice-1"]["difficulty"] = "advanced"
+        difficulty_slices["contracts-slice-2"]["difficulty"] = "foundation"
+        with self.assertRaises(core.SpecError):
+            core.validate_learning_path(
+                difficulty_path, self.cycle, slices=difficulty_slices
+            )
+
+    def test_learning_rejects_checkpoint_and_assessment_id_collisions(self):
+        duplicated_path, duplicated_slices = learning_fixture()
+        duplicated_path["areas"][1]["checkpoint"]["question_id"] = duplicated_path[
+            "areas"
+        ][0]["checkpoint"]["question_id"]
+        with self.assertRaises(core.SpecError):
+            core.validate_learning_path(
+                duplicated_path, self.cycle, slices=duplicated_slices
+            )
+
+        colliding_path, colliding_slices = learning_fixture()
+        colliding_path["areas"][0]["checkpoint"]["question_id"] = "assessment-q00"
+        with self.assertRaises(core.SpecError):
+            core.validate_learning_path(
+                colliding_path,
+                self.cycle,
+                slices=colliding_slices,
+                assessment_spec=assessment_spec(),
+            )
+
+        kernel_path, kernel_slices = learning_fixture()
+        kernel_path["areas"][0]["checkpoint"]["knowledge_kernel_id"] = "kernel-00"
+        with self.assertRaises(core.SpecError):
+            core.validate_learning_path(
+                kernel_path,
+                self.cycle,
+                slices=kernel_slices,
+                assessment_spec=assessment_spec(),
+            )
+
+        linked_path, linked_slices = learning_fixture()
+        linked_slices["contracts-slice-1"]["assessment_question_ids"] = [
+            "missing-question"
+        ]
+        with self.assertRaises(core.SpecError):
+            core.validate_learning_path(
+                linked_path,
+                self.cycle,
+                slices=linked_slices,
+                assessment_spec=assessment_spec(),
+            )
+
+    def test_learning_completion_rejects_tampered_event_content(self):
+        with tempfile.TemporaryDirectory() as directory:
+            learning_dir = Path(directory)
+            first = self.path["areas"][0]["slice_ids"][0]
+            core.record_slice_completion(
+                learning_dir,
+                self.path,
+                self.raw_slices,
+                first,
+                "tamper-fixture",
+            )
+            event = learning_dir / "events" / f"slice_completed.{first}.json"
+            event.write_text("{}", encoding="utf-8")
+            with self.assertRaises(core.SpecError):
+                core.learning_completion_state(
+                    learning_dir, self.path, slices=self.raw_slices
+                )
+
+    def test_first_event_seals_future_learning_content(self):
+        with tempfile.TemporaryDirectory() as directory:
+            learning_dir = Path(directory)
+            first = self.path["areas"][0]["slice_ids"][0]
+            core.record_slice_completion(
+                learning_dir,
+                self.path,
+                self.raw_slices,
+                first,
+                "seal-learning-contract",
+            )
+            changed_slices = json.loads(json.dumps(self.raw_slices))
+            changed_slices["contracts-slice-2"]["core_explanation"] = (
+                "Mutated future learning content."
+            )
+            with self.assertRaises(core.SpecError):
+                core.learning_completion_state(
+                    learning_dir, self.path, slices=changed_slices
+                )
+
+    def test_first_learning_event_rejects_answer_revealing_checkpoint_copy(self):
+        raw_path, raw_slices = learning_fixture()
+        raw_path["areas"][0]["checkpoint"]["options"][0]["description"] = (
+            "這個選項就是正確答案。"
+        )
+        path = core.validate_learning_path(
+            raw_path, self.cycle, slices=raw_slices
+        )
+        with tempfile.TemporaryDirectory() as directory:
+            learning_dir = Path(directory)
+            first = path["areas"][0]["slice_ids"][0]
+            with self.assertRaises(core.SpecError):
+                core.record_slice_completion(
+                    learning_dir,
+                    path,
+                    raw_slices,
+                    first,
+                    "unsafe-learning-copy",
+                )
+            self.assertFalse((learning_dir / "events").exists())
+
+    def test_gap_formula_and_mapping_are_enforced(self):
+        raw_path, raw_slices = learning_fixture(
+            {"contracts": 6, "recovery": 5, "evidence": 5}
+        )
+        gap = {
+            "gap_id": "assessment.assessment-q00",
+            "area_id": "contracts",
+            "knowledge_kernel_id": "kernel-00",
+            "source_question_id": "assessment-q00",
+        }
+        report = {"gaps": [gap]}
+        with self.assertRaises(core.SpecError):
+            core.validate_learning_path(
+                raw_path,
+                self.cycle,
+                slices=raw_slices,
+                assessment_report=report,
+            )
+        raw_slices["contracts-slice-1"]["addresses_gap_ids"] = [gap["gap_id"]]
+        normalized = core.validate_learning_path(
+            raw_path,
+            self.cycle,
+            slices=raw_slices,
+            assessment_report=report,
+        )
+        self.assertEqual(len(normalized["areas"][0]["slice_ids"]), 6)
+        unlinked_path, unlinked_slices = learning_fixture(
+            {"contracts": 6, "recovery": 5, "evidence": 5}
+        )
+        unlinked_slices["contracts-slice-1"]["addresses_gap_ids"] = [
+            gap["gap_id"]
+        ]
+        unlinked_slices["contracts-slice-1"]["assessment_question_ids"] = [
+            "assessment-q03"
+        ]
+        with self.assertRaises(core.SpecError):
+            core.validate_learning_path(
+                unlinked_path,
+                self.cycle,
+                slices=unlinked_slices,
+                assessment_report=report,
+            )
+        wrong_area_path, wrong_area_slices = learning_fixture(
+            {"contracts": 6, "recovery": 5, "evidence": 5}
+        )
+        wrong_area_slices["recovery-slice-1"]["addresses_gap_ids"] = [gap["gap_id"]]
+        with self.assertRaises(core.SpecError):
+            core.validate_learning_path(
+                wrong_area_path,
+                self.cycle,
+                slices=wrong_area_slices,
+                assessment_report=report,
+            )
+
+    def test_review_gate_requires_every_slice_and_checkpoint(self):
+        with tempfile.TemporaryDirectory() as directory:
+            learning_dir = Path(directory)
+            with self.assertRaises(core.IncompleteLearningError):
+                core.ensure_review_ready(
+                    learning_dir, self.path, slices=self.raw_slices
+                )
+            for area in self.path["areas"]:
+                for slice_id in area["slice_ids"]:
+                    core.record_slice_completion(
+                        learning_dir,
+                        self.path,
+                        self.raw_slices,
+                        slice_id,
+                        f"complete-{slice_id}",
+                    )
+                checkpoint_item = area["checkpoint"]
+                core.record_checkpoint_response(
+                    learning_dir,
+                    self.path,
+                    area["area_id"],
+                    checkpoint_item["correct_option_id"],
+                    [option["id"] for option in checkpoint_item["options"]],
+                    f"checkpoint-{area['area_id']}",
+                    slices=self.raw_slices,
+                )
+            state = core.ensure_review_ready(
+                learning_dir, self.path, slices=self.raw_slices
+            )
+            self.assertTrue(state["complete"])
+            report = core.build_learning_report(
+                learning_dir, self.path, slices=self.raw_slices
+            )
+            self.assertEqual(report["mastery_effect"], "learning_progress_only")
+            self.assertTrue(report["review_ready"])
+            self.assertEqual(report["gaps"], [])
+
+    def test_checkpoint_wrong_is_saved_without_blocking_completion(self):
+        with tempfile.TemporaryDirectory() as directory:
+            learning_dir = Path(directory)
+            for area in self.path["areas"]:
+                for slice_id in area["slice_ids"]:
+                    core.record_slice_completion(
+                        learning_dir,
+                        self.path,
+                        self.raw_slices,
+                        slice_id,
+                        f"complete-{slice_id}",
+                    )
+                checkpoint_item = area["checkpoint"]
+                wrong = next(
+                    option["id"]
+                    for option in checkpoint_item["options"]
+                    if option["id"] != checkpoint_item["correct_option_id"]
+                )
+                selected = wrong if area["area_id"] == "contracts" else checkpoint_item["correct_option_id"]
+                core.record_checkpoint_response(
+                    learning_dir,
+                    self.path,
+                    area["area_id"],
+                    selected,
+                    [option["id"] for option in checkpoint_item["options"]],
+                    f"checkpoint-{area['area_id']}",
+                    slices=self.raw_slices,
+                )
+            report = core.build_learning_report(
+                learning_dir, self.path, slices=self.raw_slices
+            )
+            self.assertTrue(report["complete"])
+            self.assertEqual(len(report["gaps"]), 1)
+            self.assertEqual(report["gaps"][0]["area_id"], "contracts")
+
+
+class ReviewValidationAndReportTests(unittest.TestCase):
+    def setUp(self):
+        self.cycle = core.validate_cycle(cycle_spec())
+        self.assessment = core.validate_assessment_spec(assessment_spec(), self.cycle)
+        raw_path, raw_slices = learning_fixture()
+        self.slices = raw_slices
+        self.learning = core.validate_learning_path(raw_path, self.cycle, slices=raw_slices)
+
+    def validate(self, value: dict):
+        return core.validate_review_spec(
+            value,
+            self.cycle,
+            assessment_spec=self.assessment,
+            learning_path=self.learning,
+            learning_slices=self.slices,
+        )
+
+    def test_review_accepts_eight_new_scenarios_with_lineage(self):
+        normalized = self.validate(review_spec())
+        self.assertEqual(len(normalized["questions"]), 8)
+        self.assertTrue(
+            all(question["source_question_id"] for question in normalized["questions"])
+        )
+
+    def test_new_review_batch_rejects_answer_revealing_description(self):
+        raw = review_spec()
+        raw["questions"][0]["options"][0]["description"] = (
+            "This is the best answer."
+        )
+        normalized = self.validate(raw)
+        with tempfile.TemporaryDirectory() as directory:
+            phase_dir = Path(directory)
+            with self.assertRaises(core.SpecError):
+                core.ensure_batch_manifest(phase_dir, normalized)
+            self.assertFalse((phase_dir / "batch-manifest.json").exists())
+
+    def test_review_rejects_reused_scenario_family_options_and_position(self):
+        cases = []
+        reused_scenario = review_spec()
+        reused_scenario["questions"][0]["scenario_context"] = self.assessment["questions"][0][
+            "scenario_context"
+        ]
+        cases.append(reused_scenario)
+        trivial_rewrite = review_spec()
+        trivial_rewrite["questions"][0]["scenario_context"] = (
+            self.assessment["questions"][0]["scenario_context"] + " Paraphrased."
+        )
+        cases.append(trivial_rewrite)
+        reused_scenario_id = review_spec()
+        reused_scenario_id["questions"][0]["scenario_id"] = self.assessment["questions"][1][
+            "scenario_id"
+        ]
+        cases.append(reused_scenario_id)
+        reused_family = review_spec()
+        reused_family["questions"][0]["question_family"] = "application"
+        cases.append(reused_family)
+        reused_option = review_spec()
+        reused_option["questions"][0]["options"][0]["id"] = self.assessment["questions"][0][
+            "options"
+        ][0]["id"]
+        cases.append(reused_option)
+        reused_description = review_spec()
+        reused_description["questions"][0]["options"][0]["description"] = (
+            self.assessment["questions"][0]["options"][0]["description"]
+        )
+        cases.append(reused_description)
+        reused_explanation = review_spec()
+        reused_explanation["questions"][0]["options"][0]["explanation"] = (
+            self.assessment["questions"][0]["options"][0]["explanation"]
+        )
+        cases.append(reused_explanation)
+        reused_position = review_spec()
+        first = reused_position["questions"][0]["options"]
+        correct_index = next(
+            index
+            for index, option in enumerate(first)
+            if option["id"] == reused_position["questions"][0]["correct_option_id"]
+        )
+        first[0], first[correct_index] = first[correct_index], first[0]
+        cases.append(reused_position)
+        reused_checkpoint = review_spec()
+        checkpoint_source = self.learning["areas"][0]["checkpoint"]
+        checkpoint_item = reused_checkpoint["questions"][0]
+        checkpoint_item["area_id"] = checkpoint_source["area_id"]
+        checkpoint_item["concept_id"] = checkpoint_source["concept_id"]
+        checkpoint_item["primary_kernel_id"] = checkpoint_source[
+            "knowledge_kernel_id"
+        ]
+        checkpoint_item["core_proposition"] = checkpoint_source[
+            "core_proposition"
+        ]
+        checkpoint_item["source_question_id"] = checkpoint_source["question_id"]
+        checkpoint_item["scenario_id"] = checkpoint_source["scenario_id"]
+        checkpoint_item["scenario_context"] = checkpoint_source[
+            "scenario_context"
+        ]
+        checkpoint_item["lineage"]["assessment_question_ids"] = [
+            "assessment-q01"
+        ]
+        checkpoint_item["lineage"]["learning_checkpoint_ids"] = [
+            checkpoint_source["question_id"]
+        ]
+        cases.append(reused_checkpoint)
+        for value in cases:
+            with self.subTest(value=value["questions"][0]):
+                with self.assertRaises(core.SpecError):
+                    self.validate(value)
+
+    def test_review_rejects_duplicate_scenario_unknown_lineage_and_no_integration(self):
+        duplicate_scenario = review_spec()
+        duplicate_scenario["questions"][1]["scenario_id"] = duplicate_scenario[
+            "questions"
+        ][0]["scenario_id"]
+        with self.assertRaises(core.SpecError):
+            self.validate(duplicate_scenario)
+
+        unknown_lineage = review_spec()
+        unknown_lineage["questions"][0]["lineage"]["assessment_question_ids"].append(
+            "unknown-assessment"
+        )
+        with self.assertRaises(core.SpecError):
+            self.validate(unknown_lineage)
+
+        no_integration = review_spec()
+        for item in no_integration["questions"]:
+            item["integrated_kernel_ids"] = []
+            item["lineage"]["assessment_question_ids"] = [item["source_question_id"]]
+        with self.assertRaises(core.SpecError):
+            self.validate(no_integration)
+
+    def test_review_requires_mission_critical_correct_kernel(self):
+        value = review_spec()
+        replacement = self.assessment["questions"][8]
+        first = value["questions"][0]
+        first["area_id"] = replacement["area_id"]
+        first["concept_id"] = replacement["concept_id"]
+        first["primary_kernel_id"] = replacement["knowledge_kernel_id"]
+        first["core_proposition"] = replacement["core_proposition"]
+        first["source_question_id"] = replacement["question_id"]
+        first["lineage"]["assessment_question_ids"] = [
+            replacement["question_id"],
+            "assessment-q01",
+        ]
+        with self.assertRaises(core.SpecError):
+            core.validate_review_spec(
+                value,
+                self.cycle,
+                assessment_spec=self.assessment,
+                learning_path=self.learning,
+                learning_slices=self.slices,
+                assessment_report={
+                    "gaps": [],
+                    "question_results": [
+                        {"question_id": "assessment-q00", "is_correct": True}
+                    ],
+                },
+            )
+
+    def test_review_report_compares_prior_gaps_and_schedules_three_days(self):
+        normalized = self.validate(review_spec())
+        assessment_report = {
+            "gaps": [
+                {
+                    "gap_id": "assessment.assessment-q00",
+                    "area_id": "contracts",
+                    "knowledge_kernel_id": "kernel-00",
+                    "source_question_id": "assessment-q00",
+                },
+                {
+                    "gap_id": "assessment.assessment-q01",
+                    "area_id": "recovery",
+                    "knowledge_kernel_id": "kernel-01",
+                    "source_question_id": "assessment-q01",
+                },
+            ]
+        }
+        with tempfile.TemporaryDirectory() as directory:
+            review_dir = Path(directory)
+            for index, item in enumerate(normalized["questions"]):
+                correct = index != 1
+                selected = item["correct_option_id"] if correct else next(
+                    option["id"]
+                    for option in item["options"]
+                    if option["id"] != item["correct_option_id"]
+                )
+                core.record_response(
+                    review_dir,
+                    normalized,
+                    item["question_id"],
+                    selected,
+                    [option["id"] for option in item["options"]],
+                    f"review-request-{index}",
+                )
+            last_response_path = (
+                review_dir
+                / "responses"
+                / f"{normalized['questions'][-1]['question_id']}.json"
+            )
+            last_response = core.read_json_object(last_response_path)
+            last_response["answered_at"] = "2026-08-27T12:00:00+00:00"
+            last_response_path.write_text(
+                json.dumps(last_response, ensure_ascii=False), encoding="utf-8"
+            )
+            report = core.build_review_report(
+                review_dir,
+                normalized,
+                assessment_report,
+                now=dt.datetime(2026, 9, 12, tzinfo=dt.timezone.utc),
+            )
+            self.assertIn("assessment.assessment-q00", report["corrected_gap_ids"])
+            self.assertIn("assessment.assessment-q01", report["remaining_gap_ids"])
+            self.assertNotIn("assessment.assessment-q01", report["corrected_gap_ids"])
+            first_result = next(
+                item
+                for item in report["question_results"]
+                if item["question_id"] == "review-q00"
+            )
+            self.assertIn(
+                "assessment.assessment-q01", first_result["integrated_gap_ids"]
+            )
+            self.assertTrue(
+                all(item["due_date"] == "2026-08-30" for item in report["delayed_review"])
+            )
+            reopened = core.build_review_report(
+                review_dir,
+                normalized,
+                assessment_report,
+                now=dt.datetime(2026, 10, 1, tzinfo=dt.timezone.utc),
+            )
+            self.assertEqual(
+                report["delayed_review"], reopened["delayed_review"]
+            )
+            self.assertEqual(
+                report["completion_anchor"], reopened["completion_anchor"]
+            )
+            self.assertEqual(len(report["integration_results"]), 8)
+
+    def test_review_question_count_follows_gap_plus_area_formula(self):
+        gaps = [
+            {
+                "gap_id": f"assessment.assessment-q{index:02d}",
+                "area_id": AREAS[index % len(AREAS)],
+                "knowledge_kernel_id": f"kernel-{index:02d}",
+                "source_question_id": f"assessment-q{index:02d}",
+            }
+            for index in range(6)
+        ]
+        counts = {
+            area: 5 + sum(gap["area_id"] == area for gap in gaps)
+            for area in AREAS
+        }
+        raw_learning, slices = learning_fixture(counts)
+        for area in AREAS:
+            area_gaps = [gap for gap in gaps if gap["area_id"] == area]
+            area_slice_ids = next(
+                item["slice_ids"]
+                for item in raw_learning["areas"]
+                if item["area_id"] == area
+            )
+            for index, gap in enumerate(area_gaps):
+                slices[area_slice_ids[index]]["addresses_gap_ids"].append(
+                    gap["gap_id"]
+                )
+                source_id = gap["source_question_id"]
+                links = slices[area_slice_ids[index]]["assessment_question_ids"]
+                if source_id not in links:
+                    links.append(source_id)
+        assessment_report = {"gaps": gaps}
+        learning = core.validate_learning_path(
+            raw_learning,
+            self.cycle,
+            slices=slices,
+            assessment_report=assessment_report,
+            assessment_spec=self.assessment,
+        )
+        with self.assertRaises(core.SpecError):
+            core.validate_review_spec(
+                review_spec(8),
+                self.cycle,
+                assessment_spec=self.assessment,
+                learning_path=learning,
+                learning_slices=slices,
+                assessment_report=assessment_report,
+            )
+        normalized = core.validate_review_spec(
+            review_spec(9),
+            self.cycle,
+            assessment_spec=self.assessment,
+            learning_path=learning,
+            learning_slices=slices,
+            assessment_report=assessment_report,
+        )
+        self.assertEqual(len(normalized["questions"]), 9)
+
+    def test_review_caps_primary_gaps_and_integrates_overflow(self):
+        expanded_assessment = core.validate_assessment_spec(
+            assessment_spec(20), self.cycle
+        )
+        gaps = [
+            {
+                "gap_id": f"assessment.assessment-q{index:02d}",
+                "source": "assessment",
+                "area_id": AREAS[index % len(AREAS)],
+                "knowledge_kernel_id": f"kernel-{index:02d}",
+                "source_question_id": f"assessment-q{index:02d}",
+                "core_proposition": f"Core decision proposition {index}.",
+                "critical": index in {0, 18},
+            }
+            for index in range(20)
+        ]
+        assessment_report = {
+            "gaps": gaps,
+            "question_results": [
+                {"question_id": f"assessment-q{index:02d}", "is_correct": False}
+                for index in range(20)
+            ],
+        }
+        counts = {area: 10 for area in AREAS}
+        raw_learning, slices = learning_fixture(counts)
+        for area in AREAS:
+            area_gaps = [gap for gap in gaps if gap["area_id"] == area]
+            area_slice_ids = next(
+                item["slice_ids"]
+                for item in raw_learning["areas"]
+                if item["area_id"] == area
+            )
+            for index, gap in enumerate(area_gaps):
+                slices[area_slice_ids[index]]["addresses_gap_ids"].append(
+                    gap["gap_id"]
+                )
+                links = slices[area_slice_ids[index]]["assessment_question_ids"]
+                if gap["source_question_id"] not in links:
+                    links.append(gap["source_question_id"])
+        learning = core.validate_learning_path(
+            raw_learning,
+            self.cycle,
+            slices=slices,
+            assessment_report=assessment_report,
+            assessment_spec=expanded_assessment,
+        )
+
+        value = review_spec(15)
+        critical_source = question(18)
+        critical_item = value["questions"][14]
+        critical_item["area_id"] = critical_source["area_id"]
+        critical_item["concept_id"] = critical_source["concept_id"]
+        critical_item["primary_kernel_id"] = critical_source["knowledge_kernel_id"]
+        critical_item["core_proposition"] = critical_source["core_proposition"]
+        critical_item["source_question_id"] = critical_source["question_id"]
+        critical_item["lineage"]["assessment_question_ids"][0] = critical_source[
+            "question_id"
+        ]
+        for overflow_index, gap_index in enumerate((14, 15, 16, 17, 19)):
+            item = value["questions"][overflow_index]
+            item["integrated_kernel_ids"].append(f"kernel-{gap_index:02d}")
+            item["lineage"]["assessment_question_ids"].append(
+                f"assessment-q{gap_index:02d}"
+            )
+        normalized = core.validate_review_spec(
+            value,
+            self.cycle,
+            assessment_spec=expanded_assessment,
+            learning_path=learning,
+            learning_slices=slices,
+            assessment_report=assessment_report,
+        )
+        self.assertEqual(len(normalized["questions"]), 15)
+
+        with tempfile.TemporaryDirectory() as directory:
+            review_dir = Path(directory)
+            for index, item in enumerate(normalized["questions"]):
+                core.record_response(
+                    review_dir,
+                    normalized,
+                    item["question_id"],
+                    item["correct_option_id"],
+                    [option["id"] for option in item["options"]],
+                    f"overflow-review-{index}",
+                )
+            report = core.build_review_report(
+                review_dir, normalized, assessment_report
+            )
+            self.assertEqual(len(report["directly_reviewed_gap_ids"]), 15)
+            self.assertEqual(len(report["not_directly_reviewed_gap_ids"]), 5)
+            self.assertEqual(len(report["corrected_gap_ids"]), 15)
+            self.assertEqual(len(report["remaining_gap_ids"]), 5)
+            self.assertTrue(
+                set(report["not_directly_reviewed_gap_ids"])
+                <= {item["gap_id"] for item in report["delayed_review"]}
+            )
+
+
+class PersistenceTests(unittest.TestCase):
+    def test_atomic_write_replaces_and_write_once_refuses_overwrite(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            atomic_path = root / "report.json"
+            core.atomic_write_json(atomic_path, {"value": 1})
+            core.atomic_write_json(atomic_path, {"value": 2})
+            self.assertEqual(core.read_json_object(atomic_path)["value"], 2)
+            once_path = root / "answer.json"
+            core.write_json_once(once_path, {"value": 1})
+            with self.assertRaises(FileExistsError):
+                core.write_json_once(once_path, {"value": 2})
+            self.assertEqual(core.read_json_object(once_path)["value"], 1)
+
+    def test_phase_lock_is_exclusive(self):
+        with tempfile.TemporaryDirectory() as directory:
+            cycle_dir = Path(directory)
+            with core.PhaseLock(cycle_dir, "assessment"):
+                with self.assertRaises(core.ConflictError):
+                    with core.PhaseLock(cycle_dir, "learning"):
+                        pass
+            state = core.read_json_object(cycle_dir / ".cycle.lock")
+            self.assertFalse(state["active"])
+
+    def test_phase_lock_recovers_after_owner_process_crashes(self):
+        with tempfile.TemporaryDirectory() as directory:
+            cycle_dir = Path(directory)
+            script = """
+import importlib.util
+import os
+import sys
+spec = importlib.util.spec_from_file_location('crash_core', sys.argv[1])
+module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(module)
+lock = module.PhaseLock(sys.argv[2], 'assessment')
+lock.__enter__()
+os._exit(0)
+"""
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    "-c",
+                    script,
+                    str(ROOT / "scripts" / "session_core.py"),
+                    str(cycle_dir),
+                ],
+                capture_output=True,
+                text=True,
+                timeout=5,
+            )
+            self.assertEqual(result.returncode, 0, result.stderr)
+            with core.PhaseLock(cycle_dir, "review"):
+                self.assertTrue((cycle_dir / ".cycle.lock").is_file())
+            self.assertFalse(
+                core.read_json_object(cycle_dir / ".cycle.lock")["active"]
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/weeks/2026/2026-w35-mastery-loop/docs/privacy-and-security.md
+++ b/weeks/2026/2026-w35-mastery-loop/docs/privacy-and-security.md
@@ -1,0 +1,41 @@
+# 資料、隱私與安全
+
+## 資料位置
+
+Mastery Loop 的 Python runtime 不需要外部 API，也不含 telemetry。新循環的規格、回答、報告、checkpoint 與 delayed review 排程都保存在學員指定 workspace 的 `mastery-sessions/<cycle-id>/`。
+
+本週公開包不含任何講師或測試者的 `mastery-sessions/`。發行內容只收錄 Git commit 中的正式技能檔案。
+
+## 分享與版本控制
+
+`mastery-sessions/` 可能包含：
+
+- 學習目標與能力缺口。
+- 每題選擇、錯誤類型與回饋時間。
+- 個人工作情境、組織名稱或專案細節。
+- 來源連結與評估依據。
+
+將工作目錄加入 Git、雲端同步、Issue、聊天室或課程成果前，先排除 `mastery-sessions/`，或逐檔匿名化。公開問題回報只提供最小 spec、錯誤訊息與可重現步驟。
+
+## 本機介面邊界
+
+- HTTP server 綁定 `127.0.0.1`，不對區域網路公開。
+- 狀態變更使用 CSRF 與 opaque tokens。
+- 伺服器驗證 phase、順序、request ID、路徑 containment 與內容格式。
+- 回應採 atomic write-once；重送相同請求不會建立第二份成績。
+- CSP、frame protection、HTML escaping 與 body limits 降低瀏覽器攻擊面。
+
+請勿自行把綁定位址改成 `0.0.0.0`，也不要透過反向代理、port forwarding 或公開 tunnel 暴露學習頁面。
+
+## 來源與高風險主題
+
+當主題涉及即時、醫療、法律、金融、安全或其他高風險判斷：
+
+- 使用當前的第一方或權威來源。
+- 將未查證 benchmark 標為 provisional。
+- 找不到可辯護答案時暫停 scoring。
+- 不把學習結果當成正式資格、診斷、許可或專業意見。
+
+## 授權
+
+本週技能、教材與程式碼依 Toolspack 根目錄 [MIT License](../../../../LICENSE) 發布。學習時引用的第三方文章、規範、題庫或教材仍受各自條款約束；保留連結與必要摘要，不要將完整受保護內容複製進 cycle 或公開成果。

--- a/weeks/2026/2026-w35-mastery-loop/docs/troubleshooting.md
+++ b/weeks/2026/2026-w35-mastery-loop/docs/troubleshooting.md
@@ -1,0 +1,71 @@
+# 疑難排解
+
+## Skill 沒有出現在清單
+
+確認安裝結構為：
+
+```text
+mastery-loop/
+├── SKILL.md
+├── agents/openai.yaml
+├── references/
+├── scripts/
+└── tests/
+```
+
+不要多包一層同名資料夾。重新啟動 Agent 工具，再用 `$mastery-loop` 明確呼叫。
+
+## Agent 沒有先顯示三個目標
+
+新循環應先提供恰好三個可點擊成果。若環境沒有原生按鈕，Agent 可使用 `click_choice_ui.py` 提供本機點擊頁面。不要以自由輸入或「請回覆 A/B/C」取代可用的點擊路徑。
+
+## `validate` 顯示 spec 錯誤
+
+先保留錯誤訊息，讓 Agent 對照對應 reference 修正 spec。常見原因：
+
+- Assessment 少於 10 題、領域少於 3 個，或重複 kernel。
+- 選項描述洩漏正解、解析或 stable ID。
+- Learning slice 數量不符合 gap 公式，或缺少 Assessment lineage。
+- Review 重複既有 scenario、題型、選項或正解位置。
+- 目錄、report、response 或 event 指向 cycle 外部。
+
+## 瀏覽器沒有開啟
+
+1. 確認 Python 3.10 以上可執行。
+2. 先執行 phase 的 `validate`。
+3. 再讓 Agent 執行 `serve --port 0`。
+4. 將 terminal 顯示的 `http://127.0.0.1:<port>/` 貼到本機瀏覽器。
+
+## 出現 phase lock
+
+同一 cycle 同一時間只允許一個 writer。先關閉舊頁面與舊程序，再從既有 checkpoint 重開。請勿刪除 responses、events、reports 或 lock 來重置成績。
+
+## 提交後斷線或 timeout
+
+保留 cycle，重新開啟相同 phase。相同 `request_id` 的 retry 會回傳既有紀錄；若同題改送另一答案，runtime 會以 conflict 拒絕，避免雙重成績。
+
+## Review 無法開始
+
+Review gate 需要：
+
+- 完整 `assessment/report.json`。
+- 所有 Learning slices 的 completion events。
+- 每個領域一份 checkpoint response。
+- 完整 `learning/report.json`。
+- 沒有另一個活躍 phase writer。
+
+讓 Agent 執行 Learning phase `validate`，依錯誤指出的缺件補齊；不要手動偽造空白 event。
+
+## Windows 測試跳過 symlink 案例
+
+Windows 未授予「建立符號連結」權限時，該測試會顯示 `skipped`。可以在允許 symlink 的隔離環境重跑；路徑 traversal、contained directory 與非法 evidence surface 仍由其他測試覆蓋。
+
+## 回報問題時提供
+
+- 作業系統、Python 與 Agent 版本。
+- cycle version、phase 與完整錯誤訊息。
+- 執行到哪個畫面，以及重新整理後看到什麼。
+- 最小且已匿名化的 spec 或檔案結構。
+- 是否曾同時啟動兩個 serve 程序。
+
+公開回報前移除姓名、組織、客戶、專案內容、作答紀錄、API Key、Cookie、私有來源與完整 `mastery-sessions/`。

--- a/weeks/2026/2026-w35-mastery-loop/docs/verification.md
+++ b/weeks/2026/2026-w35-mastery-loop/docs/verification.md
@@ -1,0 +1,71 @@
+# Mastery Loop 驗證方式
+
+## 發行來源邊界
+
+- 來源快照：`mastery-loop` Git commit `038b14406f7afb872d6efc1f78a2ecbebed5b9cd`。
+- 發行包只採用該 commit 的 17 個 tracked files。
+- 來源中的 `.git/` 與未追蹤 `mastery-sessions/` 不在發行包內。
+- `completed/mastery-loop/` 的 17 個檔案與來源 commit 逐檔 Git blob hash 相符。
+
+## 1. Python 與技能結構
+
+在 `completed/mastery-loop/` 執行：
+
+```powershell
+$env:PYTHONUTF8='1'
+$env:PYTHONDONTWRITEBYTECODE='1'
+python -m unittest discover -s tests -v
+python C:\path\to\skill-creator\scripts\quick_validate.py .
+git diff --check
+```
+
+本次發行驗證結果：
+
+- 四個 Python scripts 語法編譯通過。
+- `quick_validate.py`：`Skill is valid!`
+- `unittest`：90 tests 通過，1 個 Windows symlink 權限案例依測試設計跳過。
+- 介面 anti-pattern 靜態掃描：0 finding。
+- 追蹤檔敏感字串掃描未發現 API Key、Cookie、密碼、個人資料或私人工作階段。
+
+跳過的 symlink 測試需要 Windows「建立符號連結」權限；其他路徑 containment、traversal 與非法 evidence surface 測試均已執行。若部署環境允許 symlink，仍應在該環境重跑完整測試。
+
+## 2. 完整流程驗證
+
+本次由獨立 Agent 在全新隔離工作目錄完成 forward test：
+
+- Scope：3 個領域。
+- Assessment：12 個獨立 kernels，6/12，三區皆為 `mixed_signal`；兩個預設隱藏 misconception 均被報告捕捉。
+- Learning：每區 7 個 slices，共 21 個；3 個 checkpoints 完成，其中 2 個刻意答錯仍可續跑。
+- Review：11/11 完成；6 個 gaps corrected、2 個 residual、1 個 newly exposed。
+- Delayed review：3 個無提示項目，固定到期日為 `2026-08-31`。
+- Reliability：相同選擇 retry 維持單一紀錄；conflicting answer 回傳 HTTP 409。
+- Evidence：所有同場 Review 記錄皆為 `feedback_exposed`，沒有宣稱 Transfer。
+- Legacy：version 2 spec 的 validate、render 與 stable-ID concealment 通過。
+
+測試另外確認 Assessment、Learning、Review 三個 public CLI phase 都回傳 `complete:true`，並在重新產生報告時保持 completion anchor、delayed queue 與既有報告不變。完整流程證據保存在隔離測試目錄，沒有複製進學員 ZIP。
+
+## 3. Toolspack 與 ZIP
+
+在 Toolspack 根目錄執行：
+
+```powershell
+powershell.exe -NoProfile -ExecutionPolicy Bypass -File .\scripts\validate-repo.ps1
+powershell.exe -NoProfile -ExecutionPolicy Bypass -File .\scripts\build-release.ps1 `
+  -WeekPath .\weeks\2026\2026-w35-mastery-loop
+git diff --check
+```
+
+ZIP 必須包含根目錄 `LICENSE`、本週教材與 `completed/mastery-loop/`；不得包含 `.git`、`mastery-sessions`、`AGENTS.md`、`SKOOL-POST.md`、`__pycache__`、憑證或另一個 ZIP。
+
+## 4. 人工驗收邊界
+
+本次自動驗證涵蓋資料結構、狀態轉移、不可變寫入、retry、路徑防護、答案防洩漏、phase reports、Learning gate、Review novelty 的確定性規則與發行包內容。
+
+以下項目需要在實際學習主題與目標 Agent 環境另行驗證：
+
+- 題目與 benchmark 的領域正確性、時效性與引用品質。
+- 新情境在語意層級是否真正不同；字串相似度檢查只能攔截部分近似案例。
+- 學員是否能在真實模擬或產物中完成端到端任務。
+- 三天後 delayed review 的真實保留表現。
+- 真人 GUI 點擊、螢幕閱讀器、響應式版面與視覺回歸；本次使用真實 loopback HTTP 流程驗證單一 base URL 與頁面狀態。
+- 正式證照、身份確認與受監管領域的治理要求。

--- a/weeks/2026/2026-w35-mastery-loop/lesson.md
+++ b/weeks/2026/2026-w35-mastery-loop/lesson.md
@@ -1,0 +1,144 @@
+# 教學講義：把學習變成可驗證、可恢復的 Agent Workflow
+
+## 學習目標
+
+完成本週練習後，你會理解：
+
+1. 如何先定義可觀察任務，再建立知識與證據邊界。
+2. 如何保留第一次作答，避免回饋污染 baseline。
+3. 如何將實際缺口轉成有先修順序的 Learning Map。
+4. 如何用新情境 Review 區分記住答案與真的會應用。
+5. 如何以不可變事件、idempotent retry 與 phase lock 維持可信狀態。
+
+## 核心模型
+
+```text
+Goal Contract
+  ↓
+Independent Assessment Evidence
+  ↓
+Gap-linked Learning Map
+  ↓
+Feedback-exposed Checkpoints
+  ↓
+New-scenario Review Evidence
+  ↓
+Delayed Uncued Evidence
+```
+
+Mastery Loop 將證據分成 `U / F / E / A / T / D`：未評估、脆弱、能解釋、能應用、能遷移、能持久。每次只晉升到現有紀錄直接支持的層級。
+
+## 模組與責任
+
+| 模組 | 責任 | 主要檔案 |
+|---|---|---|
+| Skill Router | 判斷新循環或 legacy resume，維持點擊優先契約 | `SKILL.md` |
+| Workspace Contract | 定義 cycle、phase、spec、response、report 與 lock | `references/workspace-schema.md` |
+| Assessment Design | 建立範圍、10–20 題批次與 report | `references/adaptive-interview.md` |
+| Learning Design | 由 gap 建立 prerequisite map、slice 與 checkpoint | `references/lesson-design.md` |
+| Review Design | 產生新情境、比較報告與 delayed review | `references/review-loop.md` |
+| Evidence Model | 控制證據等級、信心與宣稱邊界 | `references/mastery-model.md` |
+| State Core | 規格驗證、不可變寫入、報告重建與 phase lock | `scripts/session_core.py` |
+| Local UI | 提供 Assessment／Learning／Review 的單分頁點擊流程 | `scripts/mastery_session_ui.py` |
+
+## 第一階段：先定義任務邊界
+
+好的起點要能被外部行為判定。例如：
+
+```text
+在不共享憑證的前提下，能把一個三任務專案拆成 Agent 分工、定義 handoff，
+並在局部失敗、timeout 與重試時保留一致狀態。
+```
+
+接著定義：
+
+- 3–6 個主要領域。
+- 包含與排除項目。
+- 正確答案的評估依據與來源狀態。
+- 最終需要做到解釋、應用、遷移或耐久的哪一層。
+- 哪些宣稱仍需要真實模擬、產物或延遲驗證。
+
+當主題缺少可靠答案、範圍不足以建立十個獨立 kernels，或涉及高風險即時資訊時，先縮小或查證後再出題。
+
+## 第二階段：建立乾淨 Assessment
+
+整批題目要在開始前生成並封存：
+
+- 10–20 題、3–6 領域、每領域至少 2 題。
+- 每題一個不同 `knowledge_kernel_id`。
+- 3–5 個平衡選項，恰好一個有依據的答案。
+- 選項副描述只補充邊界、前提、取捨或遺漏條件。
+- 每個選項都有提交後才顯示的解析。
+
+提交後先寫入不可變 response，再顯示回饋。報告由 server-side spec 與 response 重建，瀏覽器不負責傳送分數或正確性。
+
+## 第三階段：用缺口建立 Learning Map
+
+每個領域的 slice 數量為：
+
+```text
+min(5 + 獨立缺口 kernel 數, 10)
+```
+
+每個 slice 都要有先修關係、可觀察學習目標、核心機制、邊界、失敗條件、全新 worked example 與 Assessment lineage。完成閱讀只代表 exposure；每個領域最後的 checkpoint 才提供有限的修正或應用證據。
+
+## 第四階段：用新情境 Review 測應用
+
+Review 題數為：
+
+```text
+clamp(Assessment 與 checkpoint 的獨立 gap kernels + 領域數, 8, 15)
+```
+
+Review 要保留核心命題，並同時更換角色、限制、產物、題型、選項、干擾項與正解位置。單純換名詞或改寫句子不算新情境。
+
+直接 scoring 的優先順序：
+
+1. 每個有缺口的領域先放最高優先缺口。
+2. 其餘 Assessment gaps 依風險排序。
+3. 再放 checkpoint gaps。
+4. 超出題數上限的 gaps 只能作為 integrated kernels，並保留在 delayed review。
+
+## 本機狀態與 API 架構
+
+```text
+Agent 產生並驗證 phase spec
+  → Local Runtime 取得 phase lock
+  → 127.0.0.1 單分頁 UI
+  → POST start / answer / next / checkpoint-answer
+  → CSRF + opaque token + 順序驗證
+  → atomic write-once record
+  → report rebuild + checkpoint resume
+```
+
+安全邊界包含：loopback 綁定、CSRF、嚴格 content type、request body 上限、HTML escaping、CSP、clickjacking 防護、路徑 containment、opaque tokens 與 constant-time token comparison。
+
+相同 `request_id` 的重試回傳既有結果；相同題目改送不同答案會拒絕。這讓 timeout 後的 retry 能維持一致狀態。
+
+## Agent Workflow 分工
+
+建議採用單一 cycle owner，並用階段角色降低上下文負擔：
+
+1. **Scope Agent**：定義任務、知識邊界、benchmark 與證據限制。
+2. **Assessment Builder**：建立完整題組與解析，通過 spec validator 後封存。
+3. **Learning Architect**：從 Assessment Report 建立 gap-linked map。
+4. **Review Designer**：建立真正的新情境批次與 lineage。
+5. **Evidence Auditor**：檢查宣稱、獨立性、提示暴露與 delayed review。
+
+所有角色只透過已保存的 phase spec、immutable records 與 report handoff。寫入 ownership 保持單一，避免兩個 Agent 同時改動同一 cycle。
+
+## Token 成本優化
+
+- 一開始保存 `cycle.json` 與來源摘要，後續階段只載入需要的 report 與 reference。
+- Assessment 一次建立完整 batch，減少逐題重新規劃與規則漂移。
+- 每個 slice 只保留支持下一次表現的最小解釋、邊界與範例。
+- Review 以 kernel lineage 選題，避免把整份教材重新送入上下文。
+- 使用 server-side report 重建，Agent 不需要重算所有歷史畫面。
+- 將殘留問題排入 delayed review，避免同一回合無限巢狀追問。
+
+## 延伸挑戰
+
+- 為自己的專業領域建立一份可引用的 benchmark registry。
+- 加入一個真實產物評分 rubric，補足 click evidence 的上限。
+- 將 delayed review 接到行事曆或任務系統，同時保留 learner authorization。
+- 用全新領域做獨立 forward test，確認規則可轉移且沒有偷讀範例答案。

--- a/weeks/2026/2026-w35-mastery-loop/metadata.yml
+++ b/weeks/2026/2026-w35-mastery-loop/metadata.yml
@@ -1,0 +1,10 @@
+id: 2026-w35
+title: Mastery Loop：可驗證的點擊式精熟學習系統
+type: skill
+difficulty: advanced
+estimated_minutes: 240
+status: stable
+published_at: 2026-08-28
+version: 1.0.0
+platform: codex-agent-skills
+license: MIT

--- a/weeks/2026/README.md
+++ b/weeks/2026/README.md
@@ -8,6 +8,7 @@
 
 | 週次 | 主題 | 類型 | 狀態 |
 |---|---|---|---|
+| [2026-W35](2026-w35-mastery-loop/README.md) | Mastery Loop：可驗證的點擊式精熟學習系統 | AI Skill | Stable |
 | [2026-W34](2026-w34-kinetic-character-reveal/README.md) | Kinetic Character Reveal：13-Cut 動態角色登場提示詞系統 | AI Skill | Stable |
 | [2026-W33](2026-w33-index-studio-indextts-2-5/README.md) | Index Studio：IndexTTS 2.5 本機語音實驗工作台 | Local AI Tool | Stable |
 | [2026-W32](2026-w32-goal-me-agent-task-brief/README.md) | Goal Me：AI Agent 目標任務書 | AI Skill | Stable |


### PR DESCRIPTION
## Summary

- add 2026-W35 `mastery-loop` as a complete public AI Skill unit
- preserve the 17 tracked source files from commit `038b14406f7afb872d6efc1f78a2ecbebed5b9cd`
- add learner README, lesson, verification, privacy/security, and troubleshooting docs
- update the root catalog, latest-content list, changelog, and 2026 index

## Validation

- [x] Toolspack repository validator passed
- [x] Skill quick validation passed
- [x] Python syntax passed
- [x] 90 unit tests passed; 1 Windows symlink-privilege case skipped by design
- [x] independent end-to-end forward test passed: 12 Assessment questions, 21 Learning slices, 3 checkpoints, 11 Review questions, and 3 delayed checks
- [x] packaged 17 files match the source commit Git blobs
- [x] ZIP contains 24 entries and no forbidden content
- [x] `git diff --check` passed

## Release boundary

- excludes source `.git/`, personal `mastery-sessions/`, cache files, credentials, instructor copy, and nested archives
- same-session Review evidence remains `feedback_exposed`; Transfer is not claimed
- real delayed performance, human GUI, screen-reader, and visual-regression checks remain outside this release validation

The read-only `repo-closeout` scanner returned `UNSUPPORTED / NOT_GIT_WORKTREE` in this isolated clone and made zero mutations. Direct Git status, repository validation, staged-diff inspection, and archive inspection completed successfully.
